### PR TITLE
Run backend via Node runtime using fork

### DIFF
--- a/app/desktop/main.js
+++ b/app/desktop/main.js
@@ -1,6 +1,6 @@
 // app/desktop/main.js
 const { app, BrowserWindow, dialog } = require('electron');
-const { spawn } = require('child_process');
+const { fork } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
@@ -40,9 +40,9 @@ function startBackend() {
   };
 
   const out = fs.createWriteStream(logFile, { flags: 'a' });
-  backend = spawn(process.execPath, [serverPath], {
+  backend = fork(serverPath, [], {
     env,
-    stdio: ['ignore', 'pipe', 'pipe'],
+    stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
     windowsHide: true,
   });
   backend.stdout.on('data', d => out.write(d));


### PR DESCRIPTION
## Summary
- start backend with `child_process.fork` and forward output to log file
- ensure `ELECTRON_RUN_AS_NODE` is set for a plain Node environment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a59c978e988320bff5cc9e79eb4a8b