### PR TITLE
Handle window lifecycle and simplify CORS

### DIFF
--- a/app/backend/src/server.ts
+++ b/app/backend/src/server.ts
@@ -13,10 +13,8 @@ const app = express();
  * CORS for dev (http://localhost:5173) and packaged Electron (file:// => no Origin header).
  * We keep it permissive for a desktop app, and answer preflight so fetch() succeeds.
  */
-// You can keep this simple allow-all:
-app.use(cors({ origin: (_origin, cb) => cb(null, true) }));
-
-// …and ensure preflight gets explicit headers for stricter UAs:
+// Allow all origins (including file:// with no Origin header) and respond to preflight
+app.use(cors());
 app.use((req, res, next) => {
   res.header('Access-Control-Allow-Origin', '*');
   res.header('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');

--- a/app/desktop/main.js
+++ b/app/desktop/main.js
@@ -76,4 +76,11 @@ function createWindow() {
 app.whenReady().then(() => {
   startBackend();
   createWindow();
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
 });


### PR DESCRIPTION
## Summary
- ensure Electron window recreates on macOS activation and quits when all windows closed
- simplify backend CORS handling while still responding to preflight

## Testing
- `npx tsc --noEmit` (backend)
- `npx tsc --noEmit` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a59fc8a8288320aebe4928ee3213a8