### PR TITLE
fix: align desktop SQLite env variable with backend

### DIFF
--- a/app/desktop/main.js
+++ b/app/desktop/main.js
@@ -34,7 +34,10 @@ function startBackend() {
     ...process.env,
     NODE_ENV: 'production',
     PORT: process.env.PORT || '3001',
-    DB_PATH: process.env.DB_PATH || path.join(dbDir, 'data.sqlite'),
+    // Ensure the backend gets a writable SQLite path.
+    // The backend expects `DATABASE_FILE`; support legacy `DB_PATH` if present.
+    DATABASE_FILE:
+      process.env.DATABASE_FILE || process.env.DB_PATH || path.join(dbDir, 'data.sqlite'),
     // IMPORTANT: this flag tells Electron to act as Node, not launch another app
     ELECTRON_RUN_AS_NODE: '1',
   };


### PR DESCRIPTION
## Summary
- ensure backend receives `DATABASE_FILE` path instead of unused `DB_PATH`
- provide fallback to legacy `DB_PATH`

## Testing
- `npm test` (desktop) *(fails: Missing script "test")*
- `npm test` (backend) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a5b2bdea8c8320b209e8506132c339