### PR TITLE
Fix serverPath to account for extra resources folder

### DIFF
--- a/app/desktop/main.js
+++ b/app/desktop/main.js
@@ -20,7 +20,7 @@ app.on('second-instance', () => {
 function startBackend() {
   if (backend) return; // guard
 
-  const serverPath = path.join(process.resourcesPath, 'backend', 'server.js');
+  const serverPath = path.join(process.resourcesPath, 'resources', 'backend', 'server.js');
   // Where we’ll log the backend output
   const logDir = path.join(app.getPath('logs'), 'quiz-study-desktop');
   const logFile = path.join(logDir, 'backend.log');


### PR DESCRIPTION
## Summary
- adjust Electron backend path to include `resources` directory in `serverPath`

## Testing
- `npm run dist` *(fails: 403 Forbidden when installing better-sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c383ba188320b0a99151bfad3930