### PR TITLE
Fix packaged frontend path in Electron main process

### DIFF
--- a/app/desktop/main.js
+++ b/app/desktop/main.js
@@ -73,7 +73,11 @@ app.on('before-quit', () => {
 function createWindow() {
   win = new BrowserWindow({ width: 1200, height: 800 });
   // Load your packaged index.html
-  win.loadFile(path.join(process.resourcesPath, 'frontend', 'index.html'));
+  // When packaged, the frontend is bundled under process.resourcesPath/resources/frontend
+  // so ensure we point to the correct location.
+  win.loadFile(
+    path.join(process.resourcesPath, 'resources', 'frontend', 'index.html')
+  );
 }
 
 app.whenReady().then(() => {


### PR DESCRIPTION
## Summary
- ensure Electron loads frontend from bundled resources folder

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run prep` *(fails: 403 Forbidden fetching better-sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cfa51e048320bc049f011be1085e