### PR TITLE
Handle missing frontend build and base path

### DIFF
--- a/app/desktop/main.js
+++ b/app/desktop/main.js
@@ -77,10 +77,20 @@ app.on('before-quit', () => {
 });
 
 function createWindow() {
-  win = new BrowserWindow({ width: 1200, height: 800 });
-const indexPath = app.isPackaged
+  const indexPath = app.isPackaged
     ? path.join(process.resourcesPath, 'frontend', 'dist', 'index.html')
     : path.join(__dirname, '..', 'frontend', 'dist', 'index.html');
+
+  if (!fs.existsSync(indexPath)) {
+    dialog.showErrorBox(
+      'Missing frontend build',
+      `Could not find \n${indexPath}\n\n` +
+        'Run `npm run build` in the frontend/ directory before starting the app.'
+    );
+    return;
+  }
+
+  win = new BrowserWindow({ width: 1200, height: 800 });
   win.loadFile(indexPath);
 }
 

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -4,7 +4,13 @@ import react from '@vitejs/plugin-react';
 // NOTE:
 // - For the browser dev server we keep base = '/'.
 // - For the desktop app we pass VITE_BASE=./ so assets resolve under file://.
+//   If the variable is not provided (e.g. someone runs a plain `npm run build`),
+//   default to a relative path in production so packaged Electron builds don't
+//   load assets from the wrong absolute location and render a blank screen.
+const isProd = process.env.NODE_ENV === 'production';
+const base = process.env.VITE_BASE || (isProd ? './' : '/');
+
 export default defineConfig({
-  base: process.env.VITE_BASE || '/',
+  base,
   plugins: [react()],
 });


### PR DESCRIPTION
## Summary
- Default Vite's base path to a relative value in production to avoid blank screens.
- Show an explicit error dialog if the packaged app can't find the built frontend.

## Testing
- `npm run build` (frontend)
- `npm test` (desktop) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6559dfc608320a061abd13350861d