### PR TITLE
Fix frontend path for packaged app

### DIFF
--- a/app/desktop/main.js
+++ b/app/desktop/main.js
@@ -78,7 +78,7 @@ app.on('before-quit', () => {
 
 function createWindow() {
   const indexPath = app.isPackaged
-    ? path.join(process.resourcesPath, 'frontend', 'dist', 'index.html')
+    ? path.join(process.resourcesPath, 'resources', 'frontend', 'index.html')
     : path.join(__dirname, '..', 'frontend', 'dist', 'index.html');
 
   if (!fs.existsSync(indexPath)) {


### PR DESCRIPTION
## Summary
- load packaged frontend from `resources/frontend` instead of missing `frontend/dist`

## Testing
- `node --check app/desktop/main.js`
- `npm --prefix app/frontend run build`
- `npm --prefix app/desktop run prep` *(fails: 403 Forbidden for better-sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_68a659c814688320afe4d5594cf8f053