### PR TITLE
Ensure backend is ready before loading UI

### DIFF
--- a/app/backend/src/server.ts
+++ b/app/backend/src/server.ts
@@ -53,4 +53,12 @@ app.use(
 /** Start */
 app.listen(ENV.PORT, () => {
   console.log(`Backend running on http://localhost:${ENV.PORT}`);
+  // Notify parent process (Electron) that the server is ready.
+  if (process.send) {
+    try {
+      process.send('ready');
+    } catch {
+      // no-op if messaging channel is unavailable
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- signal when the backend server is ready to accept requests
- delay opening the Electron window until the backend signals readiness

## Testing
- `npm test` *(backend) — missing script: "test"*
- `npm run build` *(backend)*
- `npm test` *(desktop) — missing script: "test"*
- `node --check main.js` *(desktop)*

------
https://chatgpt.com/codex/tasks/task_e_68a665f02f6083208d875876079c0a54