### PR TITLE
Ensure backend uses correct working directory

### DIFF
--- a/app/desktop/main.js
+++ b/app/desktop/main.js
@@ -50,6 +50,7 @@ function startBackend() {
     env,
     stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
     windowsHide: true,
+    cwd: path.dirname(serverPath),
   });
   backend.stdout.on('data', d => out.write(d));
   backend.stderr.on('data', d => out.write(d));


### PR DESCRIPTION
## Summary
- specify the backend process working directory when launching it from the desktop app

## Testing
- `npm run prep` *(fails: 403 Forbidden - GET https://registry.npmjs.org/better-sqlite3)*
- `npx electron .` *(fails: error while loading shared libraries: libatk-1.0.so.0)*
- `node -r dotenv/config -e "console.log('Loaded key:', process.env.OPENAI_API_KEY)"`

------
https://chatgpt.com/codex/tasks/task_e_68a6c9f3ed188320b8629321ee784aad