### PR TITLE
Add folder-based organization for decks

### DIFF
--- a/app/backend/src/db.ts
+++ b/app/backend/src/db.ts
@@ -23,18 +23,31 @@ function hasColumn(table: string, col: string) {
 }
 
 export function migrate() {
+  // Folders to group decks
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS Folders (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      createdAt INTEGER DEFAULT (strftime('%s','now') * 1000)
+    );
+  `);
+
   // Decks
   db.exec(`
     CREATE TABLE IF NOT EXISTS Decks (
       id TEXT PRIMARY KEY,
       name TEXT NOT NULL,
       source_text TEXT DEFAULT '',
+      folderId TEXT,
       createdAt INTEGER DEFAULT (strftime('%s','now') * 1000)
     );
   `);
-  // Add source_text to old Decks if missing
+  // Add missing columns to old Decks
   if (!hasColumn('Decks', 'source_text')) {
     db.exec(`ALTER TABLE Decks ADD COLUMN source_text TEXT DEFAULT ''`);
+  }
+  if (!hasColumn('Decks', 'folderId')) {
+    db.exec(`ALTER TABLE Decks ADD COLUMN folderId TEXT`);
   }
 
   // Questions

--- a/app/backend/src/routes/decks.ts
+++ b/app/backend/src/routes/decks.ts
@@ -46,14 +46,15 @@ decksRouter.post('/', async (req, res) => {
     .object({
       name: z.string().min(1),
       text: z.string().min(1),
+      folderId: z.string().uuid().optional(),
     })
     .safeParse(req.body);
 
   if (!body.success) return res.status(400).json({ error: body.error.message });
-  const { name, text } = body.data;
+  const { name, text, folderId } = body.data;
 
   const id = randomUUID();
-  db.prepare(`INSERT INTO Decks (id, name, source_text) VALUES (?, ?, ?)`).run(id, name, text);
+  db.prepare(`INSERT INTO Decks (id, name, source_text, folderId) VALUES (?, ?, ?, ?)`).run(id, name, text, folderId ?? null);
 
   try {
     const items = await generateAIBatch(text, 75);
@@ -92,8 +93,8 @@ decksRouter.post('/', async (req, res) => {
 decksRouter.get('/:id', (req, res) => {
   const id = req.params.id;
   const deck = db
-    .prepare(`SELECT id, name, source_text FROM Decks WHERE id = ?`)
-    .get(id) as { id: string; name: string; source_text: string } | undefined;
+    .prepare(`SELECT id, name, source_text, folderId FROM Decks WHERE id = ?`)
+    .get(id) as { id: string; name: string; source_text: string; folderId: string | null } | undefined;
 
   if (!deck) return res.status(404).json({ error: 'Deck not found' });
 
@@ -112,6 +113,7 @@ decksRouter.get('/:id', (req, res) => {
     id: deck.id,
     name: deck.name,
     text: deck.source_text ?? '',
+    folderId: deck.folderId ?? null,
     totalQuestions: Number(totalRow?.n ?? 0),
     mastered: Number(masteredRow?.n ?? 0),
     unmastered: Math.max(0, Number(totalRow?.n ?? 0) - Number(masteredRow?.n ?? 0)),
@@ -125,6 +127,7 @@ decksRouter.put('/:id', async (req, res) => {
     .object({
       name: z.string().optional(),
       text: z.string().optional(),
+      folderId: z.string().uuid().nullable().optional(),
       regenerate: z.boolean().optional().default(false),
       batchSize: z.number().int().min(25).max(250).optional().default(100),
     })
@@ -138,6 +141,8 @@ decksRouter.put('/:id', async (req, res) => {
 
   if (name !== undefined) db.prepare(`UPDATE Decks SET name = ? WHERE id = ?`).run(name, id);
   if (text !== undefined) db.prepare(`UPDATE Decks SET source_text = ? WHERE id = ?`).run(text, id);
+  if (payload.data.folderId !== undefined)
+    db.prepare(`UPDATE Decks SET folderId = ? WHERE id = ?`).run(payload.data.folderId ?? null, id);
 
   if (!regenerate) return res.json({ ok: true });
 

--- a/app/backend/src/routes/folders.ts
+++ b/app/backend/src/routes/folders.ts
@@ -1,0 +1,78 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { db } from '../db.js';
+import { randomUUID } from 'crypto';
+
+export const foldersRouter = Router();
+
+foldersRouter.get('/', (_req, res) => {
+  const folderRows = db
+    .prepare(`SELECT id, name FROM Folders ORDER BY createdAt DESC`)
+    .all() as Array<{ id: string; name: string }>;
+
+  const folders = folderRows.map((f) => {
+    const deckRows = db
+      .prepare(`SELECT id, name FROM Decks WHERE folderId = ? ORDER BY createdAt DESC`)
+      .all(f.id) as Array<{ id: string; name: string }>;
+
+    const decks = deckRows.map((d) => {
+      const totalRow = db
+        .prepare(`SELECT COUNT(*) as n FROM Questions WHERE deckId = ?`)
+        .get(d.id) as { n: number };
+      const masteredRow = db
+        .prepare(`
+          SELECT COUNT(*) as n FROM Questions q
+          JOIN Mastery m ON m.questionId = q.id
+          WHERE q.deckId = ? AND m.correctCount >= 2
+        `)
+        .get(d.id) as { n: number };
+      const total = Number(totalRow?.n ?? 0);
+      const mastered = Number(masteredRow?.n ?? 0);
+      return {
+        id: d.id,
+        name: d.name,
+        totalQuestions: total,
+        mastered,
+        unmastered: Math.max(0, total - mastered),
+      };
+    });
+
+    return { id: f.id, name: f.name, decks };
+  });
+
+  res.json({ folders });
+});
+
+foldersRouter.post('/', (req, res) => {
+  const body = z.object({ name: z.string().min(1) }).safeParse(req.body);
+  if (!body.success) return res.status(400).json({ error: body.error.message });
+  const id = randomUUID();
+  db.prepare(`INSERT INTO Folders (id, name) VALUES (?, ?)`).run(id, body.data.name);
+  res.json({ id });
+});
+
+foldersRouter.put('/:id', (req, res) => {
+  const id = req.params.id;
+  const body = z.object({ name: z.string().min(1) }).safeParse(req.body);
+  if (!body.success) return res.status(400).json({ error: body.error.message });
+  db.prepare(`UPDATE Folders SET name = ? WHERE id = ?`).run(body.data.name, id);
+  res.json({ ok: true });
+});
+
+foldersRouter.delete('/:id', (req, res) => {
+  const id = req.params.id;
+  const decks = db
+    .prepare(`SELECT id FROM Decks WHERE folderId = ?`)
+    .all(id) as Array<{ id: string }>;
+  for (const d of decks) {
+    db.prepare(
+      `DELETE FROM Mastery WHERE questionId IN (SELECT id FROM Questions WHERE deckId = ?)`
+    ).run(d.id);
+    db.prepare(`DELETE FROM Questions WHERE deckId = ?`).run(d.id);
+    db.prepare(`DELETE FROM Decks WHERE id = ?`).run(d.id);
+  }
+  db.prepare(`DELETE FROM Folders WHERE id = ?`).run(id);
+  res.json({ ok: true });
+});
+
+export default foldersRouter;

--- a/app/backend/src/server.ts
+++ b/app/backend/src/server.ts
@@ -6,6 +6,7 @@ import { ENV } from './env.js';
 import { decksRouter } from './routes/decks.js';
 import { quizRouter } from './routes/quiz.js';
 import { questionsRouter } from './routes/questions.js';
+import { foldersRouter } from './routes/folders.js';
 
 const app = express();
 
@@ -39,6 +40,7 @@ app.get('/health', (_req: Request, res: Response) => {
 app.use('/decks', decksRouter);
 app.use('/quiz', quizRouter);
 app.use('/questions', questionsRouter);
+app.use('/folders', foldersRouter);
 
 /** Typed error handler */
 app.use(

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -8,21 +8,53 @@ export type DeckMeta = {
   unmastered: number;
 };
 
-export async function createDeck(name: string, text: string) {
+export type FolderMeta = {
+  id: string;
+  name: string;
+  decks: DeckMeta[];
+};
+
+export async function createDeck(name: string, text: string, folderId?: string) {
   const r = await fetch(`${BASE}/decks`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, text }),
+    body: JSON.stringify({ name, text, folderId }),
   });
   if (!r.ok) throw new Error(await r.text().catch(()=>'Failed to create deck'));
   return r.json() as Promise<{ deckId: string; countsByType: any }>;
 }
 
-export async function listDecks() {
-  const r = await fetch(`${BASE}/decks`);
-  if (!r.ok) throw new Error('Failed to list decks');
+export async function listFolders() {
+  const r = await fetch(`${BASE}/folders`);
+  if (!r.ok) throw new Error('Failed to list folders');
   const j = await r.json();
-  return j.decks as DeckMeta[];
+  return j.folders as FolderMeta[];
+}
+
+export async function createFolder(name: string) {
+  const r = await fetch(`${BASE}/folders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+  if (!r.ok) throw new Error(await r.text().catch(()=>'Failed to create folder'));
+  return r.json() as Promise<{ id: string }>;
+}
+
+export async function updateFolder(folderId: string, data: { name: string }) {
+  const r = await fetch(`${BASE}/folders/${folderId}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!r.ok) throw new Error(await r.text().catch(()=>'Failed to update folder'));
+  return r.json();
+}
+
+export async function deleteFolder(folderId: string) {
+  const r = await fetch(`${BASE}/folders/${folderId}`, { method: 'DELETE' });
+  if (!r.ok) throw new Error(await r.text().catch(()=>'Failed to delete folder'));
+  return r.json();
 }
 
 export type QuizQuestion = {
@@ -66,6 +98,7 @@ export type DeckDetail = {
   id: string;
   name: string;
   text: string; // notes
+  folderId: string | null;
   totalQuestions: number;
   mastered: number;
   unmastered: number;
@@ -77,7 +110,10 @@ export async function getDeckDetail(deckId: string) {
   return r.json() as Promise<DeckDetail>;
 }
 
-export async function updateDeck(deckId: string, data: { name?: string; text?: string; regenerate?: boolean; batchSize?: number }) {
+export async function updateDeck(
+  deckId: string,
+  data: { name?: string; text?: string; folderId?: string | null; regenerate?: boolean; batchSize?: number }
+) {
   const r = await fetch(`${BASE}/decks/${deckId}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },

--- a/app/frontend/src/pages/Dashboard.tsx
+++ b/app/frontend/src/pages/Dashboard.tsx
@@ -1,21 +1,36 @@
 import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { listDecks, type DeckMeta, updateDeck, deleteDeck } from '../lib/api';
+import {
+  listFolders,
+  type FolderMeta,
+  updateDeck,
+  deleteDeck,
+  createFolder,
+  updateFolder,
+  deleteFolder,
+} from '../lib/api';
 
 export default function Dashboard() {
-  const [decks, setDecks] = useState<DeckMeta[]>([]);
+  const [folders, setFolders] = useState<FolderMeta[]>([]);
   const [loading, setLoading] = useState(true);
   const [rename, setRename] = useState<Record<string, string>>({});
+  const [folderRename, setFolderRename] = useState<Record<string, string>>({});
+  const [newFolder, setNewFolder] = useState('');
   const nav = useNavigate();
 
   async function refresh() {
     setLoading(true);
     try {
-      const d = await listDecks();
-      setDecks(d);
+      const f = await listFolders();
+      setFolders(f);
       const r: Record<string, string> = {};
-      d.forEach((x) => (r[x.id] = x.name));
+      const fr: Record<string, string> = {};
+      f.forEach((folder) => {
+        fr[folder.id] = folder.name;
+        folder.decks.forEach((x) => (r[x.id] = x.name));
+      });
       setRename(r);
+      setFolderRename(fr);
     } catch (e: any) {
       alert(e?.message || 'Failed to load decks');
     } finally {
@@ -34,6 +49,15 @@ export default function Dashboard() {
     }
   }
 
+  async function onFolderRename(id: string) {
+    try {
+      await updateFolder(id, { name: folderRename[id] ?? '' });
+      await refresh();
+    } catch (e: any) {
+      alert(e?.message || 'Rename failed');
+    }
+  }
+
   async function onDelete(id: string) {
     if (!confirm('Delete this deck?')) return;
     try {
@@ -44,45 +68,128 @@ export default function Dashboard() {
     }
   }
 
+  async function onFolderDelete(id: string) {
+    if (!confirm('Delete this folder and its decks?')) return;
+    try {
+      await deleteFolder(id);
+      await refresh();
+    } catch (e: any) {
+      alert(e?.message || 'Delete failed');
+    }
+  }
+
+  async function onCreateFolder() {
+    if (!newFolder.trim()) return;
+    try {
+      await createFolder(newFolder.trim());
+      setNewFolder('');
+      await refresh();
+    } catch (e: any) {
+      alert(e?.message || 'Create failed');
+    }
+  }
+
   if (loading) return <div className="p-6">Loading…</div>;
 
   return (
-    <div className="p-6 max-w-5xl mx-auto">
+    <div className="p-6 max-w-5xl mx-auto space-y-8">
       <div className="flex items-center justify-between mb-4">
-        <h1 className="text-2xl font-semibold">Your Decks</h1>
-        <Link className="btn" to="/new">New Deck</Link>
+        <h1 className="text-2xl font-semibold">Your Folders</h1>
+        <div className="flex gap-2">
+          <input
+            className="input p-2 border rounded"
+            placeholder="New folder"
+            value={newFolder}
+            onChange={(e) => setNewFolder(e.target.value)}
+          />
+          <button className="btn" onClick={onCreateFolder}>Add</button>
+        </div>
       </div>
 
-      {!decks.length && <div className="text-slate-500">No decks yet. Create one!</div>}
+      {!folders.length && <div className="text-slate-500">No folders yet. Create one!</div>}
 
-      <div className="grid gap-4">
-        {decks.map((d) => (
-          <div key={d.id} className="card p-4 border rounded">
+      <div className="grid gap-8">
+        {folders.map((f) => (
+          <div key={f.id} className="border rounded p-4 space-y-4">
             <div className="flex items-center justify-between">
-              <div className="font-medium">{d.name}</div>
-              <div className="text-sm text-slate-500">
-                {d.mastered}/{d.totalQuestions} mastered
+              <div className="font-semibold text-lg">{f.name}</div>
+              <div className="flex items-center gap-2">
+                <input
+                  className="input p-2 border rounded"
+                  value={folderRename[f.id] ?? ''}
+                  onChange={(e) =>
+                    setFolderRename((r) => ({ ...r, [f.id]: e.target.value }))
+                  }
+                />
+                <button className="btn" onClick={() => onFolderRename(f.id)}>
+                  Save
+                </button>
+                <Link className="btn" to={`/new?folder=${f.id}`}>
+                  New Deck
+                </Link>
+                <button
+                  className="btn bg-red-600 hover:bg-red-700"
+                  onClick={() => onFolderDelete(f.id)}
+                >
+                  Delete
+                </button>
               </div>
             </div>
 
-            <div className="mt-3 grid md:grid-cols-2 gap-3">
-              <div>
-                <label className="label">Rename</label>
-                <div className="flex gap-2">
-                  <input
-                    className="input p-2 border rounded w-full"
-                    value={rename[d.id] ?? ''}
-                    onChange={(e) => setRename((r) => ({ ...r, [d.id]: e.target.value }))}
-                  />
-                  <button className="btn" onClick={() => onRename(d.id)}>Save</button>
-                </div>
-              </div>
+            {!f.decks.length && (
+              <div className="text-slate-500">No decks in this folder.</div>
+            )}
 
-              <div className="flex md:justify-end items-end gap-2">
-                <button className="btn" onClick={() => nav(`/study?deck=${d.id}`)}>Study</button>
-                <button className="btn" onClick={() => nav(`/edit/${d.id}`)}>Edit Notes</button>
-                <button className="btn bg-red-600 hover:bg-red-700" onClick={() => onDelete(d.id)}>Delete</button>
-              </div>
+            <div className="grid gap-4">
+              {f.decks.map((d) => (
+                <div key={d.id} className="card p-4 border rounded">
+                  <div className="flex items-center justify-between">
+                    <div className="font-medium">{d.name}</div>
+                    <div className="text-sm text-slate-500">
+                      {d.mastered}/{d.totalQuestions} mastered
+                    </div>
+                  </div>
+
+                  <div className="mt-3 grid md:grid-cols-2 gap-3">
+                    <div>
+                      <label className="label">Rename</label>
+                      <div className="flex gap-2">
+                        <input
+                          className="input p-2 border rounded w-full"
+                          value={rename[d.id] ?? ''}
+                          onChange={(e) =>
+                            setRename((r) => ({ ...r, [d.id]: e.target.value }))
+                          }
+                        />
+                        <button className="btn" onClick={() => onRename(d.id)}>
+                          Save
+                        </button>
+                      </div>
+                    </div>
+
+                    <div className="flex md:justify-end items-end gap-2">
+                      <button
+                        className="btn"
+                        onClick={() => nav(`/study?deck=${d.id}`)}
+                      >
+                        Study
+                      </button>
+                      <button
+                        className="btn"
+                        onClick={() => nav(`/edit/${d.id}`)}
+                      >
+                        Edit Notes
+                      </button>
+                      <button
+                        className="btn bg-red-600 hover:bg-red-700"
+                        onClick={() => onDelete(d.id)}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
         ))}

--- a/app/frontend/src/pages/NewDeck.tsx
+++ b/app/frontend/src/pages/NewDeck.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import { createDeck } from '../lib/api';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 export default function NewDeck() {
   const nav = useNavigate();
+  const [params] = useSearchParams();
+  const folderId = params.get('folder') || undefined;
   const [name, setName] = useState('');
   const [text, setText] = useState('');
   const [loading, setLoading] = useState(false);
@@ -15,7 +17,7 @@ export default function NewDeck() {
     }
     setLoading(true);
     try {
-      const out = await createDeck(name.trim(), text.trim());
+      const out = await createDeck(name.trim(), text.trim(), folderId);
       alert('Deck created!');
       nav(`/edit/${out.deckId}`); // jump into editor for further tweaks if desired
     } catch (e: any) {

--- a/app/frontend/src/pages/Study.tsx
+++ b/app/frontend/src/pages/Study.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { listDecks, startSession, DeckMeta } from '../lib/api';
+import { listFolders, startSession, DeckMeta, FolderMeta } from '../lib/api';
 import QuizRunner from '../components/QuizRunner';
 
 type Mode = 'Mixed' | 'Weak' | 'Due';
@@ -18,10 +18,11 @@ export default function Study() {
   useEffect(() => {
     (async () => {
       try {
-        const ds = await listDecks();
+        const fs = await listFolders();
+        const ds = fs.flatMap((f: FolderMeta) => f.decks);
         setDecks(ds);
         const preselect = sp.get('deck');
-        if (preselect && ds.find(d => d.id === preselect)) {
+        if (preselect && ds.find((d) => d.id === preselect)) {
           setDeckId(preselect);
         } else if (!deckId && ds[0]) {
           setDeckId(ds[0].id);


### PR DESCRIPTION
## Summary
- support folders in database and API
- manage folders and deck assignment from frontend
- update study workflow to load decks from folders

## Testing
- `cd app/backend && npm run build`
- `cd app/frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a71ee2539c832099f18d3f359b81eb