### PR TITLE
Shuffle quiz options and track answer mapping

### DIFF
--- a/app/frontend/src/components/QuestionMCQ.tsx
+++ b/app/frontend/src/components/QuestionMCQ.tsx
@@ -5,13 +5,15 @@ type Props = {
     id: string;
     prompt: string;
     options: { a: string; b: string; c: string; d: string };
+    answerMap: { a: string; b: string; c: string; d: string };
   };
   onSubmit: (answer: string) => void;
   disabled?: boolean;
 };
 
 export default function QuestionMCQ({ question, onSubmit, disabled }: Props) {
-  const [selected, setSelected] = useState<string>('');
+  type Key = keyof typeof question.options;
+  const [selected, setSelected] = useState<Key | ''>('');
 
   // Reset selection on every new question
   useEffect(() => {
@@ -19,7 +21,9 @@ export default function QuestionMCQ({ question, onSubmit, disabled }: Props) {
   }, [question.id]);
 
   function handleKeyDown(e: React.KeyboardEvent) {
-    if (e.key === 'Enter' && selected && !disabled) onSubmit(selected);
+    if (e.key === 'Enter' && selected && !disabled) {
+      onSubmit(question.answerMap[selected as Key]);
+    }
   }
 
   const groupName = `mcq-${question.id}`; // unique group prevents carry-over
@@ -42,7 +46,11 @@ export default function QuestionMCQ({ question, onSubmit, disabled }: Props) {
         </label>
       ))}
       <div className="pt-1">
-        <button className="btn" disabled={!selected || disabled} onClick={() => onSubmit(selected)}>
+        <button
+          className="btn"
+          disabled={!selected || disabled}
+          onClick={() => onSubmit(question.answerMap[selected as Key])}
+        >
           Submit
         </button>
       </div>

--- a/app/frontend/src/components/QuizRunner.tsx
+++ b/app/frontend/src/components/QuizRunner.tsx
@@ -10,6 +10,7 @@ export type QuizQuestion = {
   type: 'MCQ' | 'CLOZE' | 'SHORT';
   prompt: string;
   options?: { a: string; b: string; c: string; d: string };
+  answerMap?: { a: string; b: string; c: string; d: string };
 };
 
 type Props = {
@@ -38,6 +39,14 @@ export default function QuizRunner({ questions, onExit }: Props) {
       current?.options && typeof current.options === 'object'
         ? current.options
         : { a: '', b: '', c: '', d: '' },
+    [current]
+  );
+
+  const safeMap = useMemo(
+    () =>
+      current?.answerMap && typeof current.answerMap === 'object'
+        ? current.answerMap
+        : { a: 'a', b: 'b', c: 'c', d: 'd' },
     [current]
   );
 
@@ -108,7 +117,7 @@ export default function QuizRunner({ questions, onExit }: Props) {
       {current?.type === 'MCQ' && (
         <QuestionMCQ
           key={current.id}
-          question={{ id: current.id, prompt: current.prompt, options: safeOptions }}
+          question={{ id: current.id, prompt: current.prompt, options: safeOptions, answerMap: safeMap }}
           onSubmit={onSubmitUserAnswer}
           disabled={loading || phase !== 'answer'}
         />

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -63,6 +63,7 @@ export type QuizQuestion = {
   type: 'MCQ' | 'CLOZE' | 'SHORT';
   prompt: string;
   options?: { a: string; b: string; c: string; d: string };
+  answerMap?: { a: string; b: string; c: string; d: string };
 };
 
 export async function startSession(deckId: string, count: number, mode: 'Mixed'|'Weak'|'Due') {


### PR DESCRIPTION
## Summary
- Shuffle MCQ options on the server, track label mapping, and limit long runs of same correct label
- Provide answer mappings to the frontend so submitted answers map back to original labels
- Update MCQ component and runner to handle shuffled options

## Testing
- `npm test` (backend) *(fails: Missing script)*
- `npm run build` (backend)
- `npm test` (frontend) *(fails: Missing script)*
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a80c7829e8832093e1d85a9298d5c1