### PR TITLE
Encourage varied AI question prompts

### DIFF
--- a/app/backend/src/ai.generate.ts
+++ b/app/backend/src/ai.generate.ts
@@ -77,7 +77,11 @@ For EVERY question include these exact fields:
 - tags (array of topical strings)
 - difficulty (integer 1–5)
 
-Ground everything strictly in the source. Avoid duplicates; vary difficulty and tags. Write ${batchTarget} total.
+Ground everything strictly in the source. Avoid duplicates; vary difficulty and tags.
+- Use diverse question stems.
+- Include scenario/application prompts.
+- Mix straightforward recall with deeper analysis questions.
+Write ${batchTarget} total.
 
 SOURCE:
 ${sourceText}


### PR DESCRIPTION
## Summary
- Instruct AI to use diverse question stems, scenarios, and recall vs analysis mix in generated questions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a80c871aa88320b7803a2098e57a18