### PR TITLE
Clarify explanation requirement in AI prompt

### DIFF
--- a/app/backend/src/ai.generate.ts
+++ b/app/backend/src/ai.generate.ts
@@ -73,7 +73,7 @@ For EVERY question include these exact fields:
 - prompt (string)
 - options (object with keys a,b,c,d). For CLOZE/SHORT still include options but set a,b,c,d to "".
 - correct_answer (string)
-- explanation (string; why the answer is correct; for MCQ mention distractor rationales)
+- explanation (string; Explain why each option (a–d) is correct or incorrect.)
 - tags (array of topical strings)
 - difficulty (integer 1–5)
 


### PR DESCRIPTION
## Summary
- Clarify that question explanations must address why each option a–d is correct or incorrect

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a80c93a3548320b64c7f4c31b811b7