### PR TITLE
Add Learning Mode quiz generation with study notes

### DIFF
--- a/app/backend/src/ai.generate.ts
+++ b/app/backend/src/ai.generate.ts
@@ -31,6 +31,7 @@ const jsonSchemaForAI = {
             'options',
             'correct_answer',
             'explanation',
+            'learning_content',
             'tags',
             'difficulty'
           ],
@@ -50,6 +51,7 @@ const jsonSchemaForAI = {
             },
             correct_answer: { type: 'string' },
             explanation: { type: 'string' },
+            learning_content: { type: 'string' },
             tags: { type: 'array', items: { type: 'string' } },
             difficulty: { type: 'integer', minimum: 1, maximum: 5 }
           }
@@ -74,6 +76,7 @@ For EVERY question include these exact fields:
 - options (object with keys a,b,c,d). For CLOZE/SHORT still include options but set a,b,c,d to "".
 - correct_answer (string)
 - explanation (string; Explain why each option (a–d) is correct or incorrect.)
+- learning_content (string; 2–4 sentence study note including concepts or facts needed to answer the question. State neutrally and avoid revealing the answer.)
 - tags (array of topical strings)
 - difficulty (integer 1–5)
 

--- a/app/backend/src/db.ts
+++ b/app/backend/src/db.ts
@@ -60,10 +60,16 @@ export function migrate() {
       options TEXT,
       correct_answer TEXT,
       explanation TEXT,
+      learning_content TEXT,
       tags TEXT,
       difficulty INTEGER DEFAULT 3
     );
   `);
+
+  // Add missing columns to old Questions
+  if (!hasColumn('Questions', 'learning_content')) {
+    db.exec(`ALTER TABLE Questions ADD COLUMN learning_content TEXT`);
+  }
 
   // Mastery
   db.exec(`
@@ -98,6 +104,7 @@ export function insertQuestion(q: {
   options?: any;
   correct_answer?: string;
   explanation?: string;
+  learning_content?: string;
   tags?: string[];
   difficulty?: number;
 }) {
@@ -105,8 +112,8 @@ export function insertQuestion(q: {
   const options = q.options ? JSON.stringify(q.options) : null;
   const tags = q.tags ? q.tags.join(',') : null;
   db.prepare(`
-    INSERT INTO Questions (id, deckId, type, prompt, options, correct_answer, explanation, tags, difficulty)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO Questions (id, deckId, type, prompt, options, correct_answer, explanation, learning_content, tags, difficulty)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     id,
     q.deckId,
@@ -115,6 +122,7 @@ export function insertQuestion(q: {
     options,
     q.correct_answer ?? null,
     q.explanation ?? null,
+    q.learning_content ?? null,
     tags,
     q.difficulty ?? 3
   );

--- a/app/backend/src/routes/decks.ts
+++ b/app/backend/src/routes/decks.ts
@@ -69,6 +69,7 @@ decksRouter.post('/', async (req, res) => {
         options: q.options ?? undefined,
         correct_answer: q.correct_answer ?? '',
         explanation: q.explanation ?? '',
+        learning_content: q.learning_content ?? '',
         tags: q.tags ?? [],
         difficulty: q.difficulty ?? 3,
       });
@@ -170,6 +171,7 @@ decksRouter.put('/:id', async (req, res) => {
         options: q.options ?? undefined,
         correct_answer: q.correct_answer ?? '',
         explanation: q.explanation ?? '',
+        learning_content: q.learning_content ?? '',
         tags: q.tags ?? [],
         difficulty: q.difficulty ?? 3,
       });

--- a/app/backend/src/routes/quiz.ts
+++ b/app/backend/src/routes/quiz.ts
@@ -84,7 +84,7 @@ quizRouter.post('/session', (req, res) => {
   const { deckId, count: requested, mode, difficulty, ratios } = parsed.data;
 
   const rows = db.prepare(`
-      SELECT q.id, q.deckId, q.type, q.prompt, q.options, q.correct_answer, q.explanation, q.tags, q.difficulty,
+      SELECT q.id, q.deckId, q.type, q.prompt, q.options, q.correct_answer, q.explanation, q.learning_content, q.tags, q.difficulty,
              COALESCE(m.correctCount, 0) AS correctCount,
              (SELECT COUNT(*) FROM Attempts a WHERE a.questionId = q.id) AS attemptCount
       FROM Questions q
@@ -189,6 +189,7 @@ quizRouter.post('/session', (req, res) => {
     deckId: r.deckId,
     type: r.type as 'MCQ' | 'CLOZE' | 'SHORT',
     prompt: r.prompt,
+    learning_content: r.learning_content,
     options: (() => { try { return JSON.parse(r.options || '{}'); } catch { return { a:'', b:'', c:'', d:'' }; } })(),
   }));
 

--- a/app/backend/src/schemas.ts
+++ b/app/backend/src/schemas.ts
@@ -18,6 +18,7 @@ export const QuestionSchema = z.object({
   options: MCQOptions.optional(),
   correct_answer: z.string().min(1),
   explanation: z.string().min(1),
+  learning_content: z.string().min(1),
   tags: z.array(z.string()).default([]),
   difficulty: z.number().int().min(1).max(5)
 });
@@ -30,6 +31,7 @@ export const AIGeneratedQuestionSchema = z.object({
   options: MCQOptions.optional().nullable(),   // <-- allow null or missing
   correct_answer: z.string().min(1),
   explanation: z.string().min(1),
+  learning_content: z.string().min(1),
   tags: z.array(z.string()).default([]),
   difficulty: z.number().int().min(1).max(5)
 });

--- a/app/frontend/src/components/QuizRunner.tsx
+++ b/app/frontend/src/components/QuizRunner.tsx
@@ -10,12 +10,14 @@ export type QuizQuestion = {
   deckId: string;
   type: 'MCQ' | 'CLOZE' | 'SHORT';
   prompt: string;
+  learning_content?: string;
   options?: { a: string; b: string; c: string; d: string };
   answerMap?: { a: string; b: string; c: string; d: string };
 };
 
 type Props = {
   questions: QuizQuestion[];
+  learningMode?: boolean;
   onExit: () => void;
 };
 
@@ -26,7 +28,7 @@ type Graded = {
   explanation: string;
 };
 
-export default function QuizRunner({ questions, onExit }: Props) {
+export default function QuizRunner({ questions, learningMode, onExit }: Props) {
   // Maintain a mutable queue so questions can be re-enqueued or removed.
   const [queue, setQueue] = useState<QuizQuestion[]>(() => [...questions]);
   const [phase, setPhase] = useState<'answer' | 'review' | 'done'>('answer');
@@ -80,7 +82,7 @@ export default function QuizRunner({ questions, onExit }: Props) {
   // Convert a question to a harder form for re-queueing after mistakes.
   function transformQuestion(q: QuizQuestion): QuizQuestion {
     if (q.type === 'MCQ' || q.type === 'CLOZE') {
-      return { id: q.id, deckId: q.deckId, type: 'SHORT', prompt: q.prompt };
+      return { id: q.id, deckId: q.deckId, type: 'SHORT', prompt: q.prompt, learning_content: q.learning_content };
     }
     return q;
   }
@@ -136,6 +138,12 @@ export default function QuizRunner({ questions, onExit }: Props) {
         <div className="font-medium">Question {asked + 1} / {asked + queue.length}</div>
         <div className="text-sm text-slate-600">{current?.type}</div>
       </div>
+
+      {learningMode && current?.learning_content && (
+        <div className="p-3 rounded bg-sky-50 whitespace-pre-wrap">
+          {current.learning_content}
+        </div>
+      )}
 
       {/* Render question component here… */}
       {current?.type === 'MCQ' && (

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -62,6 +62,7 @@ export type QuizQuestion = {
   deckId: string;
   type: 'MCQ' | 'CLOZE' | 'SHORT';
   prompt: string;
+  learning_content?: string;
   options?: { a: string; b: string; c: string; d: string };
   answerMap?: { a: string; b: string; c: string; d: string };
 };

--- a/app/frontend/src/pages/Study.tsx
+++ b/app/frontend/src/pages/Study.tsx
@@ -10,6 +10,7 @@ export default function Study() {
   const [deckId, setDeckId] = useState<string>('');
   const [mode, setMode] = useState<Mode>('Mixed');
   const [count, setCount] = useState<number>(50);
+  const [learningMode, setLearningMode] = useState(false);
   const [loading, setLoading] = useState(false);
   const [questions, setQuestions] = useState<any[] | null>(null);
   const [sp] = useSearchParams();
@@ -90,6 +91,14 @@ export default function Study() {
               <option>Weak</option>
               <option>Due</option>
             </select>
+            <label className="mt-2 flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={learningMode}
+                onChange={e => setLearningMode(e.target.checked)}
+              />
+              <span>Learning Mode</span>
+            </label>
           </div>
 
           <div>
@@ -124,6 +133,7 @@ export default function Study() {
       {questions && questions.length > 0 && (
         <QuizRunner
           questions={questions}
+          learningMode={learningMode}
           onExit={() => setQuestions(null)}
         />
       )}


### PR DESCRIPTION
## Summary
- extend database and schemas to store `learning_content` for questions
- generate Learning Mode study notes alongside questions
- add UI toggle and rendering for Learning Mode

## Testing
- `npm test` (backend) *(fails: Missing script)*
- `npm run build` (backend)
- `npm test` (frontend) *(fails: Missing script)*
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a85e2fd3548320b039b5dde83edeb6