### PR TITLE
feat: add detailed answer review with definitions

### DIFF
--- a/app/frontend/src/components/QuestionCloze.tsx
+++ b/app/frontend/src/components/QuestionCloze.tsx
@@ -13,7 +13,7 @@ export default function QuestionCloze({ question, onSubmit, disabled }: Props) {
   useEffect(() => { setValue(''); }, [question.id]);
 
   function handleKeyDown(e: React.KeyboardEvent) {
-    if (e.key === 'Enter' && value.trim() && !disabled) onSubmit(value.trim());
+    if (e.key === 'Enter' && value.trim() && !disabled) onSubmit(value);
   }
 
   return (
@@ -26,7 +26,7 @@ export default function QuestionCloze({ question, onSubmit, disabled }: Props) {
         placeholder="Type the missing word/phrase"
         disabled={disabled}
       />
-      <button className="btn" disabled={!value.trim() || disabled} onClick={() => onSubmit(value.trim())}>
+      <button className="btn" disabled={!value.trim() || disabled} onClick={() => onSubmit(value)}>
         Submit
       </button>
     </div>

--- a/app/frontend/src/components/QuestionShort.tsx
+++ b/app/frontend/src/components/QuestionShort.tsx
@@ -14,7 +14,7 @@ export default function QuestionShort({ question, onSubmit, disabled }: Props) {
 
   function handleKeyDown(e: React.KeyboardEvent) {
     if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'enter' && value.trim() && !disabled) {
-      onSubmit(value.trim());
+      onSubmit(value);
     }
   }
 
@@ -29,7 +29,7 @@ export default function QuestionShort({ question, onSubmit, disabled }: Props) {
         placeholder="Type your answer (⌘/Ctrl + Enter to submit)"
         disabled={disabled}
       />
-      <button className="btn" disabled={!value.trim() || disabled} onClick={() => onSubmit(value.trim())}>
+      <button className="btn" disabled={!value.trim() || disabled} onClick={() => onSubmit(value)}>
         Submit
       </button>
     </div>

--- a/app/frontend/src/components/QuizRunner.tsx
+++ b/app/frontend/src/components/QuizRunner.tsx
@@ -25,6 +25,9 @@ type Graded = {
   questionId: string;
   isCorrect: boolean;
   correct_answer: string;
+  user_answer: string;
+  correct_definition: string;
+  user_definition: string;
   explanation: string;
 };
 
@@ -68,6 +71,9 @@ export default function QuizRunner({ questions, learningMode, onExit }: Props) {
           questionId: current.id,
           isCorrect: r.isCorrect,
           correct_answer: r.correct_answer,
+          user_answer: r.user_answer,
+          correct_definition: r.correct_definition,
+          user_definition: r.user_definition,
           explanation: r.explanation,
         },
       ]);
@@ -177,9 +183,18 @@ export default function QuizRunner({ questions, learningMode, onExit }: Props) {
           <div className="font-semibold mb-1">
             {graded[graded.length - 1].isCorrect ? 'Correct ✅' : 'Incorrect ❌'}
           </div>
-          <div className="text-sm">
-            <div><span className="font-medium">Answer:</span> {graded[graded.length - 1].correct_answer}</div>
-            <div className="mt-1 whitespace-pre-wrap">{graded[graded.length - 1].explanation}</div>
+          <div className="text-sm space-y-1">
+            <div>
+              <span className="font-medium">Your Answer:</span> {graded[graded.length - 1].user_answer}
+              {' '}
+              <span className="text-slate-600">– {graded[graded.length - 1].user_definition || 'No definition available.'}</span>
+            </div>
+            <div>
+              <span className="font-medium">Correct Answer:</span> {graded[graded.length - 1].correct_answer}
+              {' '}
+              <span className="text-slate-600">– {graded[graded.length - 1].correct_definition || 'No definition available.'}</span>
+            </div>
+            <div className="whitespace-pre-wrap">{graded[graded.length - 1].explanation}</div>
           </div>
           <div className="mt-3">
             <button className="btn" onClick={goNext}>Next</button>

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -93,6 +93,9 @@ export async function submitAnswer(questionId: string, userAnswer: string) {
   return r.json() as Promise<{
     isCorrect: boolean;
     correct_answer: string;
+    user_answer: string;
+    correct_definition: string;
+    user_definition: string;
     explanation: string;
     correctCount: number;
     mastered: boolean;


### PR DESCRIPTION
## Summary
- return user's submitted answer and definitions from `/quiz/submit`
- track and display user/correct answer with short definitions in quiz review panel
- forward raw text answers from cloze and short question components

## Testing
- `cd app/backend && npm test` *(fails: Missing script "test")*
- `cd app/backend && npm run build`
- `cd app/frontend && npm test` *(fails: Missing script "test")*
- `cd app/frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af972dabe8832080c51ded9c304a28