### PR TITLE
feat: add completion state before mastery

### DIFF
--- a/app/backend/src/routes/folders.ts
+++ b/app/backend/src/routes/folders.ts
@@ -19,6 +19,13 @@ foldersRouter.get('/', (_req, res) => {
       const totalRow = db
         .prepare(`SELECT COUNT(*) as n FROM Questions WHERE deckId = ?`)
         .get(d.id) as { n: number };
+      const completedRow = db
+        .prepare(`
+          SELECT COUNT(*) as n FROM Questions q
+          JOIN Mastery m ON m.questionId = q.id
+          WHERE q.deckId = ? AND m.correctCount = 1
+        `)
+        .get(d.id) as { n: number };
       const masteredRow = db
         .prepare(`
           SELECT COUNT(*) as n FROM Questions q
@@ -27,13 +34,15 @@ foldersRouter.get('/', (_req, res) => {
         `)
         .get(d.id) as { n: number };
       const total = Number(totalRow?.n ?? 0);
+      const completed = Number(completedRow?.n ?? 0);
       const mastered = Number(masteredRow?.n ?? 0);
       return {
         id: d.id,
         name: d.name,
         totalQuestions: total,
+        completed,
         mastered,
-        unmastered: Math.max(0, total - mastered),
+        unmastered: Math.max(0, total - mastered - completed),
       };
     });
 

--- a/app/backend/src/routes/quiz.ts
+++ b/app/backend/src/routes/quiz.ts
@@ -294,6 +294,7 @@ quizRouter.post('/submit', async (req, res) => {
       user_definition: userDefinition,
       explanation,
       correctCount: newStreak,
+      completed: newStreak >= 1,
       mastered: newStreak >= 2,
     });
   } catch (err: any) {

--- a/app/frontend/src/components/AnalyticsPanel.tsx
+++ b/app/frontend/src/components/AnalyticsPanel.tsx
@@ -3,14 +3,15 @@ import type { DeckMeta } from '../lib/api';
 
 /**
  * Simple analytics panel aligned with the current DeckMeta shape:
- * { id, name, totalQuestions, mastered, unmastered }
+ * { id, name, totalQuestions, completed, mastered, unmastered }
  */
 type Props = { deck: DeckMeta };
 
 export default function AnalyticsPanel({ deck }: Props) {
   const total = Number(deck.totalQuestions ?? 0);
+  const completed = Number(deck.completed ?? 0);
   const mastered = Number(deck.mastered ?? 0);
-  const unmastered = Number(deck.unmastered ?? Math.max(0, total - mastered));
+  const unmastered = Number(deck.unmastered ?? Math.max(0, total - mastered - completed));
   const accuracy = total > 0 ? Math.round((mastered / total) * 100) : 0;
 
   return (
@@ -18,6 +19,7 @@ export default function AnalyticsPanel({ deck }: Props) {
       <div className="text-sm text-slate-600 mb-2">Deck analytics</div>
       <div className="flex flex-wrap gap-2">
         <span className="badge">Total: {total}</span>
+        <span className="badge">Completed: {completed}</span>
         <span className="badge">Mastered: {mastered}</span>
         <span className="badge">Unmastered: {unmastered}</span>
         <span className="badge">Accuracy: {accuracy}%</span>

--- a/app/frontend/src/lib/api.ts
+++ b/app/frontend/src/lib/api.ts
@@ -4,6 +4,7 @@ export type DeckMeta = {
   id: string;
   name: string;
   totalQuestions: number;
+  completed: number;
   mastered: number;
   unmastered: number;
 };
@@ -98,6 +99,7 @@ export async function submitAnswer(questionId: string, userAnswer: string) {
     user_definition: string;
     explanation: string;
     correctCount: number;
+    completed: boolean;
     mastered: boolean;
   }>;
 }
@@ -110,6 +112,7 @@ export type DeckDetail = {
   text: string; // notes
   folderId: string | null;
   totalQuestions: number;
+  completed: number;
   mastered: number;
   unmastered: number;
 };

--- a/app/frontend/src/pages/Dashboard.tsx
+++ b/app/frontend/src/pages/Dashboard.tsx
@@ -146,7 +146,7 @@ export default function Dashboard() {
                   <div className="flex items-center justify-between">
                     <div className="font-medium">{d.name}</div>
                     <div className="text-sm text-slate-500">
-                      {d.mastered}/{d.totalQuestions} mastered
+                      {d.completed}/{d.totalQuestions} completed · {d.mastered} mastered
                     </div>
                   </div>
 

--- a/app/frontend/src/pages/EditDeck.tsx
+++ b/app/frontend/src/pages/EditDeck.tsx
@@ -14,8 +14,8 @@ export default function EditDeck() {
   const [name, setName] = useState('');
   const [text, setText] = useState('');
 
-  const [stats, setStats] = useState<{ total: number; mastered: number; unmastered: number }>({
-    total: 0, mastered: 0, unmastered: 0,
+  const [stats, setStats] = useState<{ total: number; completed: number; mastered: number; unmastered: number }>({
+    total: 0, completed: 0, mastered: 0, unmastered: 0,
   });
 
   useEffect(() => {
@@ -26,7 +26,7 @@ export default function EditDeck() {
         if (!mounted) return;
         setName(d.name);
         setText(d.text || '');
-        setStats({ total: d.totalQuestions, mastered: d.mastered, unmastered: d.unmastered });
+        setStats({ total: d.totalQuestions, completed: d.completed, mastered: d.mastered, unmastered: d.unmastered });
       } catch (e: any) {
         alert(e?.message || 'Failed to load deck');
         setError(e?.message || 'Failed to load deck');
@@ -109,6 +109,7 @@ export default function EditDeck() {
 
         <div className="text-sm text-slate-600">
           <span className="badge mr-2">Total: {stats.total}</span>
+          <span className="badge mr-2">Completed: {stats.completed}</span>
           <span className="badge mr-2">Mastered: {stats.mastered}</span>
           <span className="badge">Unmastered: {stats.unmastered}</span>
         </div>


### PR DESCRIPTION
## Summary
- add completed counts to deck and folder APIs alongside mastered
- return completed flag from quiz submissions
- expose completion stats in frontend types and UI

## Testing
- `npm test` *(backend) — fails: Missing script "test"*
- `npm run build` *(backend)*
- `npm test` *(frontend) — fails: Missing script "test"*
- `npm run build` *(frontend)*

------
https://chatgpt.com/codex/tasks/task_e_68b50e0437348320823b21597a83e1fc