### PR TITLE
Allow Enter key to advance to next question

### DIFF
--- a/app/frontend/src/components/QuizRunner.tsx
+++ b/app/frontend/src/components/QuizRunner.tsx
@@ -141,6 +141,17 @@ export default function QuizRunner({ questions, learningMode, onExit }: Props) {
     }
   }, [phase]);
 
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Enter' && phase === 'review') {
+        e.preventDefault();
+        goNext();
+      }
+    }
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [phase, goNext]);
+
   if (!current && phase !== 'done') {
     // Nothing to show (empty session)
     return (
@@ -227,7 +238,7 @@ export default function QuizRunner({ questions, learningMode, onExit }: Props) {
             <div className="whitespace-pre-wrap">{graded[graded.length - 1].explanation}</div>
           </div>
           <div className="mt-3">
-            <button className="btn" onClick={goNext}>Next</button>
+            <button className="btn" onClick={goNext}>Next (Enter)</button>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Let Enter move to the next quiz question during review
- Indicate the Enter shortcut on the review Next button

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b908c830c88320b4af72ebac6c09af