### PR TITLE
fix: remove stray text in Study page

### DIFF
--- a/app/frontend/src/pages/Study.tsx
+++ b/app/frontend/src/pages/Study.tsx
@@ -23,8 +23,6 @@ function shuffle<T>(arr: T[]): T[] {
 
 export default function Study() {
   const [decks, setDecks] = useState<DeckMeta[]>([]);
-  the user wants to know where to put this code? yes, replaced lines 1–end.
-
   const [deckId, setDeckId] = useState<string>('');
   const [mode, setMode] = useState<Mode>('Mixed');
   const [count, setCount] = useState<number>(50);


### PR DESCRIPTION
## Summary
- remove accidental text line from Study page

## Testing
- `npm run dist` *(fails: 403 Forbidden - GET https://registry.npmjs.org/better-sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_68b91e51daa48320b7b795cc41ef12a3