### PR TITLE
Sync progress with server

### DIFF
--- a/app/frontend/src/components/QuizRunner.tsx
+++ b/app/frontend/src/components/QuizRunner.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { submitAnswer } from '../lib/api';
-import { recordCorrect } from '../lib/progress';
+import { recordProgress } from '../lib/progress';
 import type { QuizQuestion } from '../lib/api';
 import QuestionMCQ from './QuestionMCQ';
 import QuestionCloze from './QuestionCloze';
@@ -34,8 +34,6 @@ export default function QuizRunner({ questions, learningMode, onExit }: Props) {
   const [phase, setPhase] = useState<'answer' | 'review' | 'done'>('answer');
   const [loading, setLoading] = useState(false);
   const [graded, setGraded] = useState<Graded[]>([]);
-  // Track consecutive correct streak per question id.
-  const [, setStreaks] = useState<Record<string, number>>({});
   const [asked, setAsked] = useState(0);
 
   const current = queue[0];
@@ -74,14 +72,7 @@ export default function QuizRunner({ questions, learningMode, onExit }: Props) {
       setGraded(g => [...g, entry]);
 
       if (deckId) {
-        setStreaks(prev => {
-          const streak = entry.isCorrect ? (prev[current.id] || 0) + 1 : 0;
-          const updated = { ...prev, [current.id]: streak };
-          if (entry.isCorrect) {
-            recordCorrect(deckId, current.id, streak);
-          }
-          return updated;
-        });
+        recordProgress(deckId, current.id, r.completed, r.mastered);
       }
       setPhase('review');
     } catch (e: any) {

--- a/app/frontend/src/lib/progress.ts
+++ b/app/frontend/src/lib/progress.ts
@@ -22,11 +22,35 @@ export function saveProgress(deckId: string, progress: DeckProgress): void {
   } catch {}
 }
 
-export function recordCorrect(deckId: string, questionId: string, streak: number) {
+export function recordProgress(
+  deckId: string,
+  questionId: string,
+  completed: boolean,
+  mastered: boolean,
+) {
   const progress = loadProgress(deckId);
-  if (!progress.completed.includes(questionId)) progress.completed.push(questionId);
-  if (streak >= 3 && !progress.mastered.includes(questionId)) {
-    progress.mastered.push(questionId);
+
+  // mastered always implies completed
+  if (mastered) completed = true;
+
+  // Update completed list
+  if (completed) {
+    if (!progress.completed.includes(questionId)) progress.completed.push(questionId);
+  } else {
+    progress.completed = progress.completed.filter(id => id !== questionId);
   }
+
+  // Update mastered list
+  if (mastered) {
+    if (!progress.mastered.includes(questionId)) progress.mastered.push(questionId);
+  } else {
+    progress.mastered = progress.mastered.filter(id => id !== questionId);
+  }
+
   saveProgress(deckId, progress);
+}
+
+// Backwards compatibility
+export function recordCorrect(deckId: string, questionId: string, streak: number) {
+  recordProgress(deckId, questionId, streak >= 1, streak >= 3);
 }


### PR DESCRIPTION
## Summary
- track completion and mastery using server response
- push mastered and completed questions to back of queue by storing progress

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b943ab4c34832093f49647a2191fc0