### PR TITLE
Add Swift Vapor backend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ desktop/release/
 resources/
 *.dmg
 *.app
+app/backend-swift/.build/
 
 # Local data & env
 .env

--- a/app/README.md
+++ b/app/README.md
@@ -9,6 +9,11 @@ cp ../.env.example ../.env   # set OPENAI_API_KEY in app/backend/.env
 npm i
 npm run dev   # http://localhost:3001
 
+### Swift Backend Prototype
+cd app/backend-swift
+swift build
+swift run   # launches the Vapor server
+
 ### Frontend
 cd app/frontend
 npm i

--- a/app/backend-swift/Package.swift
+++ b/app/backend-swift/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "QuizStudyServer",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "Run", targets: ["Run"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.88.0"),
+        .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.5.0")
+    ],
+    targets: [
+        .target(
+            name: "App",
+            dependencies: [
+                .product(name: "Vapor", package: "vapor"),
+                .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver")
+            ],
+            swiftSettings: [
+                .unsafeFlags(["-warnings-as-errors"], .when(configuration: .release))
+            ]
+        ),
+        .executableTarget(
+            name: "Run",
+            dependencies: ["App"]
+        )
+    ]
+)

--- a/app/backend-swift/Sources/App/Controllers/DecksController.swift
+++ b/app/backend-swift/Sources/App/Controllers/DecksController.swift
@@ -46,7 +46,26 @@ final class DecksController {
     }
 
     func create(req: Request) async throws -> CreateDeckResponse {
-        throw Abort(.notImplemented)
+        let payload = try req.content.decode(CreateDeckRequest.self)
+        try payload.validate()
+
+        let deckId = UUID()
+        try await req.db.sql().raw(
+            """
+            INSERT INTO "Decks" (id, name, source_text, folderId)
+            VALUES (\(bind: deckId.uuidString), \(bind: payload.name), \(bind: payload.text), \(bind: payload.folderId?.uuidString))
+            """
+        ).run()
+
+        do {
+            let questions = try await AIQuestionGenerator.generateBatch(text: payload.text, batchSize: 75, on: req)
+            try await insertGeneratedQuestions(questions, deckId: deckId, on: req)
+            let counts = try await questionCounts(for: deckId, on: req)
+            return CreateDeckResponse(deckId: deckId, countsByType: counts)
+        } catch {
+            req.logger.error("POST /decks error: \(error.localizedDescription)")
+            throw Abort(.internalServerError, reason: error.localizedDescription)
+        }
     }
 
     func fetch(req: Request) async throws -> DeckDetailResponse {
@@ -76,7 +95,102 @@ final class DecksController {
     }
 
     func update(req: Request) async throws -> UpdateDeckResponse {
-        throw Abort(.notImplemented)
+        let deckId = try req.parameters.require("id", as: UUID.self)
+        let payload = try req.content.decode(UpdateDeckRequest.self)
+        try payload.validate()
+
+        guard try await deckExists(deckId, on: req) else {
+            throw Abort(.notFound, reason: "Deck not found")
+        }
+
+        if let name = payload.name {
+            try await req.db.sql().raw(
+                """
+                UPDATE "Decks"
+                SET name = \(bind: name)
+                WHERE id = \(bind: deckId.uuidString)
+                """
+            ).run()
+        }
+
+        if let text = payload.text {
+            try await req.db.sql().raw(
+                """
+                UPDATE "Decks"
+                SET source_text = \(bind: text)
+                WHERE id = \(bind: deckId.uuidString)
+                """
+            ).run()
+        }
+
+        if let folderIdField = payload.folderId {
+            try await req.db.sql().raw(
+                """
+                UPDATE "Decks"
+                SET folderId = \(bind: folderIdField.value?.uuidString)
+                WHERE id = \(bind: deckId.uuidString)
+                """
+            ).run()
+        }
+
+        guard payload.shouldRegenerate else {
+            return UpdateDeckResponse(ok: true, total: nil, countsByType: nil)
+        }
+
+        try await req.db.sql().raw(
+            """
+            DELETE FROM "Mastery"
+            WHERE questionId IN (
+                SELECT id FROM "Questions" WHERE deckId = \(bind: deckId.uuidString)
+            )
+            """
+        ).run()
+
+        try await req.db.sql().raw(
+            """
+            DELETE FROM "Questions"
+            WHERE deckId = \(bind: deckId.uuidString)
+            """
+        ).run()
+
+        let sourceText: String
+        if let text = payload.text {
+            sourceText = text
+        } else {
+            let row = try await req.db.sql().raw(
+                """
+                SELECT source_text
+                FROM "Decks"
+                WHERE id = \(bind: deckId.uuidString)
+                LIMIT 1
+                """
+            ).first(decoding: DeckSourceRow.self)
+            sourceText = row?.sourceText ?? ""
+        }
+
+        do {
+            let questions = try await AIQuestionGenerator.generateBatch(
+                text: sourceText,
+                batchSize: payload.batchSize,
+                on: req
+            )
+            try await insertGeneratedQuestions(questions, deckId: deckId, on: req)
+        } catch {
+            req.logger.error("PUT /decks/:id regenerate error: \(error.localizedDescription)")
+            throw Abort(.internalServerError, reason: error.localizedDescription)
+        }
+
+        let total = try await count(
+            on: req,
+            """
+            SELECT COUNT(*) as n
+            FROM "Questions"
+            WHERE deckId = \(bind: deckId.uuidString)
+            """
+        )
+
+        let counts = try await questionCounts(for: deckId, on: req)
+        return UpdateDeckResponse(ok: true, total: total, countsByType: counts)
     }
 
     func reset(req: Request) async throws -> OKResponse {
@@ -145,6 +259,37 @@ final class DecksController {
         ).first() != nil
     }
 
+    private func insertGeneratedQuestions(_ questions: [AIGeneratedQuestion], deckId: UUID, on req: Request) async throws {
+        for question in questions {
+            _ = try await req.insertQuestion(
+                InsertQuestion(
+                    deckId: deckId,
+                    type: question.type.rawValue,
+                    prompt: question.prompt,
+                    options: question.options,
+                    correctAnswer: question.correctAnswer,
+                    explanation: question.explanation,
+                    learningContent: question.learningContent,
+                    tags: question.tags,
+                    difficulty: question.difficulty
+                )
+            )
+        }
+    }
+
+    private func questionCounts(for deckId: UUID, on req: Request) async throws -> [QuestionTypeCount] {
+        let rows = try await req.db.sql().raw(
+            """
+            SELECT type, COUNT(*) as n
+            FROM "Questions"
+            WHERE deckId = \(bind: deckId.uuidString)
+            GROUP BY type
+            """
+        ).all(decoding: QuestionTypeCountRow.self)
+
+        return rows.map { QuestionTypeCount(type: $0.type, n: Int($0.n)) }
+    }
+
     private func deckMetrics(for deckId: UUID, on req: Request) async throws -> DeckMetrics {
         let total = try await count(
             on: req,
@@ -208,6 +353,98 @@ private struct DeckMetrics {
     let total: Int
     let completed: Int
     let mastered: Int
+}
+
+private struct DeckSourceRow: Decodable {
+    let sourceText: String
+
+    enum CodingKeys: String, CodingKey {
+        case sourceText = "source_text"
+    }
+}
+
+private struct QuestionTypeCountRow: Decodable {
+    let type: String
+    let n: Int64
+}
+
+struct CreateDeckRequest: Content {
+    let name: String
+    let text: String
+    let folderId: UUID?
+
+    func validate() throws {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            throw Abort(.badRequest, reason: "Name is required")
+        }
+
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty else {
+            throw Abort(.badRequest, reason: "Text is required")
+        }
+    }
+}
+
+struct UpdateDeckRequest: Content {
+    let name: String?
+    let text: String?
+    let folderId: NullableUUIDField?
+    let regenerateRaw: Bool?
+    let batchSizeRaw: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case text
+        case folderId
+        case regenerateRaw = "regenerate"
+        case batchSizeRaw = "batchSize"
+    }
+
+    var shouldRegenerate: Bool { regenerateRaw ?? false }
+
+    var batchSize: Int {
+        let size = batchSizeRaw ?? 100
+        return max(25, min(250, size))
+    }
+
+    func validate() throws {
+        if let name = name, name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            throw Abort(.badRequest, reason: "Name cannot be empty")
+        }
+
+        if let text = text, text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            throw Abort(.badRequest, reason: "Text cannot be empty")
+        }
+
+        if let batchSize = batchSizeRaw, (batchSize < 25 || batchSize > 250) {
+            throw Abort(.badRequest, reason: "batchSize must be between 25 and 250")
+        }
+    }
+}
+
+enum NullableUUIDField: Decodable {
+    case value(UUID)
+    case null
+
+    var value: UUID? {
+        switch self {
+        case .value(let id):
+            return id
+        case .null:
+            return nil
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else {
+            let value = try container.decode(UUID.self)
+            self = .value(value)
+        }
+    }
 }
 
 struct DeckListResponse: Content {

--- a/app/backend-swift/Sources/App/Controllers/DecksController.swift
+++ b/app/backend-swift/Sources/App/Controllers/DecksController.swift
@@ -1,0 +1,83 @@
+import Vapor
+
+final class DecksController {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(use: list)
+        routes.post(use: create)
+        routes.get(":id", use: fetch)
+        routes.put(":id", use: update)
+        routes.post(":id", "reset", use: reset)
+        routes.delete(":id", use: remove)
+    }
+
+    func list(req: Request) async throws -> DeckListResponse {
+        throw Abort(.notImplemented)
+    }
+
+    func create(req: Request) async throws -> CreateDeckResponse {
+        throw Abort(.notImplemented)
+    }
+
+    func fetch(req: Request) async throws -> DeckDetailResponse {
+        throw Abort(.notImplemented)
+    }
+
+    func update(req: Request) async throws -> UpdateDeckResponse {
+        throw Abort(.notImplemented)
+    }
+
+    func reset(req: Request) async throws -> OKResponse {
+        throw Abort(.notImplemented)
+    }
+
+    func remove(req: Request) async throws -> OKResponse {
+        throw Abort(.notImplemented)
+    }
+}
+
+struct DeckListResponse: Content {
+    let decks: [DeckSummary]
+}
+
+struct DeckSummary: Content {
+    let id: UUID
+    let name: String
+    let totalQuestions: Int
+    let mastered: Int
+    let completed: Int
+    let unmastered: Int
+}
+
+struct CreateDeckResponse: Content {
+    let deckId: UUID
+    let countsByType: [QuestionTypeCount]
+}
+
+struct QuestionTypeCount: Content {
+    let type: String
+    let n: Int
+}
+
+struct DeckDetailResponse: Content {
+    let id: UUID
+    let name: String
+    let text: String
+    let folderId: UUID?
+    let totalQuestions: Int
+    let completed: Int
+    let mastered: Int
+    let unmastered: Int
+}
+
+struct UpdateDeckResponse: Content {
+    let ok: Bool
+    let total: Int?
+    let countsByType: [QuestionTypeCount]?
+}
+
+struct OKResponse: Content {
+    let ok: Bool
+    init(ok: Bool = true) {
+        self.ok = ok
+    }
+}

--- a/app/backend-swift/Sources/App/Controllers/DecksController.swift
+++ b/app/backend-swift/Sources/App/Controllers/DecksController.swift
@@ -1,3 +1,5 @@
+import Fluent
+import SQLKit
 import Vapor
 
 final class DecksController {
@@ -11,7 +13,36 @@ final class DecksController {
     }
 
     func list(req: Request) async throws -> DeckListResponse {
-        throw Abort(.notImplemented)
+        let rows = try await req.db.sql().raw(
+            """
+            SELECT id, name
+            FROM "Decks"
+            ORDER BY createdAt DESC
+            """
+        ).all(decoding: DeckRow.self)
+
+        var decks: [DeckSummary] = []
+        decks.reserveCapacity(rows.count)
+
+        for row in rows {
+            guard let deckId = UUID(uuidString: row.id) else {
+                req.logger.warning("Skipping deck with invalid UUID: \(row.id)")
+                continue
+            }
+
+            let metrics = try await deckMetrics(for: deckId, on: req)
+            let summary = DeckSummary(
+                id: deckId,
+                name: row.name,
+                totalQuestions: metrics.total,
+                mastered: metrics.mastered,
+                completed: metrics.completed,
+                unmastered: max(0, metrics.total - metrics.mastered - metrics.completed)
+            )
+            decks.append(summary)
+        }
+
+        return DeckListResponse(decks: decks)
     }
 
     func create(req: Request) async throws -> CreateDeckResponse {
@@ -19,7 +50,29 @@ final class DecksController {
     }
 
     func fetch(req: Request) async throws -> DeckDetailResponse {
-        throw Abort(.notImplemented)
+        let deckId = try req.parameters.require("id", as: UUID.self)
+        guard let row = try await req.db.sql().raw(
+            """
+            SELECT id, name, source_text, folderId
+            FROM "Decks"
+            WHERE id = \(bind: deckId.uuidString)
+            LIMIT 1
+            """
+        ).first(decoding: DeckRecord.self) else {
+            throw Abort(.notFound, reason: "Deck not found")
+        }
+
+        let metrics = try await deckMetrics(for: deckId, on: req)
+        return DeckDetailResponse(
+            id: deckId,
+            name: row.name,
+            text: row.sourceText ?? "",
+            folderId: row.folderId.flatMap(UUID.init(uuidString:)),
+            totalQuestions: metrics.total,
+            completed: metrics.completed,
+            mastered: metrics.mastered,
+            unmastered: max(0, metrics.total - metrics.mastered - metrics.completed)
+        )
     }
 
     func update(req: Request) async throws -> UpdateDeckResponse {
@@ -27,12 +80,134 @@ final class DecksController {
     }
 
     func reset(req: Request) async throws -> OKResponse {
-        throw Abort(.notImplemented)
+        let deckId = try req.parameters.require("id", as: UUID.self)
+        guard try await deckExists(deckId, on: req) else {
+            throw Abort(.notFound, reason: "Deck not found")
+        }
+
+        try await req.db.sql().raw(
+            """
+            DELETE FROM "Mastery"
+            WHERE questionId IN (
+                SELECT id FROM "Questions" WHERE deckId = \(bind: deckId.uuidString)
+            )
+            """
+        ).run()
+
+        try await req.db.sql().raw(
+            """
+            DELETE FROM "Attempts"
+            WHERE questionId IN (
+                SELECT id FROM "Questions" WHERE deckId = \(bind: deckId.uuidString)
+            )
+            """
+        ).run()
+
+        return OKResponse()
     }
 
     func remove(req: Request) async throws -> OKResponse {
-        throw Abort(.notImplemented)
+        let deckId = try req.parameters.require("id", as: UUID.self)
+
+        try await req.db.sql().raw(
+            """
+            DELETE FROM "Mastery"
+            WHERE questionId IN (
+                SELECT id FROM "Questions" WHERE deckId = \(bind: deckId.uuidString)
+            )
+            """
+        ).run()
+
+        try await req.db.sql().raw(
+            """
+            DELETE FROM "Questions"
+            WHERE deckId = \(bind: deckId.uuidString)
+            """
+        ).run()
+
+        try await req.db.sql().raw(
+            """
+            DELETE FROM "Decks"
+            WHERE id = \(bind: deckId.uuidString)
+            """
+        ).run()
+
+        return OKResponse()
     }
+
+    private func deckExists(_ deckId: UUID, on req: Request) async throws -> Bool {
+        try await req.db.sql().raw(
+            """
+            SELECT 1 FROM "Decks"
+            WHERE id = \(bind: deckId.uuidString)
+            LIMIT 1
+            """
+        ).first() != nil
+    }
+
+    private func deckMetrics(for deckId: UUID, on req: Request) async throws -> DeckMetrics {
+        let total = try await count(
+            on: req,
+            """
+            SELECT COUNT(*) as n
+            FROM "Questions"
+            WHERE deckId = \(bind: deckId.uuidString)
+            """
+        )
+
+        let completed = try await count(
+            on: req,
+            """
+            SELECT COUNT(*) as n
+            FROM "Questions" q
+            JOIN "Mastery" m ON m.questionId = q.id
+            WHERE q.deckId = \(bind: deckId.uuidString) AND m.correctCount = 1
+            """
+        )
+
+        let mastered = try await count(
+            on: req,
+            """
+            SELECT COUNT(*) as n
+            FROM "Questions" q
+            JOIN "Mastery" m ON m.questionId = q.id
+            WHERE q.deckId = \(bind: deckId.uuidString) AND m.correctCount >= 2
+            """
+        )
+
+        return DeckMetrics(total: total, completed: completed, mastered: mastered)
+    }
+
+    private func count(on req: Request, _ query: SQLQueryString) async throws -> Int {
+        struct CountRow: Decodable { let n: Int64 }
+        let row = try await req.db.sql().raw(query).first(decoding: CountRow.self)
+        return row.map { Int($0.n) } ?? 0
+    }
+}
+
+private struct DeckRow: Decodable {
+    let id: String
+    let name: String
+}
+
+private struct DeckRecord: Decodable {
+    let id: String
+    let name: String
+    let sourceText: String?
+    let folderId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case sourceText = "source_text"
+        case folderId
+    }
+}
+
+private struct DeckMetrics {
+    let total: Int
+    let completed: Int
+    let mastered: Int
 }
 
 struct DeckListResponse: Content {

--- a/app/backend-swift/Sources/App/Controllers/FoldersController.swift
+++ b/app/backend-swift/Sources/App/Controllers/FoldersController.swift
@@ -1,0 +1,49 @@
+import Vapor
+
+final class FoldersController {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(use: list)
+        routes.post(use: create)
+        routes.put(":id", use: rename)
+        routes.delete(":id", use: remove)
+    }
+
+    func list(req: Request) async throws -> FolderListResponse {
+        throw Abort(.notImplemented)
+    }
+
+    func create(req: Request) async throws -> CreateFolderResponse {
+        throw Abort(.notImplemented)
+    }
+
+    func rename(req: Request) async throws -> OKResponse {
+        throw Abort(.notImplemented)
+    }
+
+    func remove(req: Request) async throws -> OKResponse {
+        throw Abort(.notImplemented)
+    }
+}
+
+struct FolderListResponse: Content {
+    let folders: [FolderSummary]
+}
+
+struct FolderSummary: Content {
+    let id: UUID
+    let name: String
+    let decks: [FolderDeckSummary]
+}
+
+struct FolderDeckSummary: Content {
+    let id: UUID
+    let name: String
+    let totalQuestions: Int
+    let completed: Int
+    let mastered: Int
+    let unmastered: Int
+}
+
+struct CreateFolderResponse: Content {
+    let id: UUID
+}

--- a/app/backend-swift/Sources/App/Controllers/QuestionsController.swift
+++ b/app/backend-swift/Sources/App/Controllers/QuestionsController.swift
@@ -1,0 +1,37 @@
+import Vapor
+
+final class QuestionsController {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(":id", use: show)
+    }
+
+    func show(req: Request) async throws -> QuestionDetail {
+        throw Abort(.notImplemented)
+    }
+}
+
+struct QuestionDetail: Content {
+    enum CodingKeys: String, CodingKey {
+        case id
+        case deckId
+        case type
+        case prompt
+        case options
+        case correctAnswer = "correct_answer"
+        case explanation
+        case learningContent = "learning_content"
+        case tags
+        case difficulty
+    }
+
+    let id: String
+    let deckId: String
+    let type: String
+    let prompt: String
+    let options: String?
+    let correctAnswer: String?
+    let explanation: String?
+    let learningContent: String?
+    let tags: String?
+    let difficulty: Int?
+}

--- a/app/backend-swift/Sources/App/Controllers/QuizController.swift
+++ b/app/backend-swift/Sources/App/Controllers/QuizController.swift
@@ -1,0 +1,70 @@
+import Vapor
+
+final class QuizController {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post("session", use: session)
+        routes.post("submit", use: submit)
+    }
+
+    func session(req: Request) async throws -> QuizSessionResponse {
+        throw Abort(.notImplemented)
+    }
+
+    func submit(req: Request) async throws -> QuizSubmitResponse {
+        throw Abort(.notImplemented)
+    }
+}
+
+struct QuizSessionResponse: Content {
+    let questions: [QuizQuestion]
+}
+
+struct QuizQuestion: Content {
+    enum CodingKeys: String, CodingKey {
+        case id
+        case deckId
+        case type
+        case prompt
+        case learningContent = "learning_content"
+        case options
+        case answerMap
+        case correctCount
+        case mastered
+    }
+
+    let id: UUID
+    let deckId: UUID
+    let type: QuizQuestionType
+    let prompt: String
+    let learningContent: String?
+    let options: [String: String]?
+    let answerMap: [String: String]?
+    let correctCount: Int
+    let mastered: Bool
+}
+
+enum QuizQuestionType: String, Content {
+    case mcq = "MCQ"
+    case cloze = "CLOZE"
+    case short = "SHORT"
+}
+
+struct QuizSubmitResponse: Content {
+    enum CodingKeys: String, CodingKey {
+        case isCorrect
+        case correctAnswer = "correct_answer"
+        case userAnswer = "user_answer"
+        case explanation
+        case correctCount
+        case completed
+        case mastered
+    }
+
+    let isCorrect: Bool
+    let correctAnswer: String
+    let userAnswer: String
+    let explanation: String
+    let correctCount: Int
+    let completed: Bool
+    let mastered: Bool
+}

--- a/app/backend-swift/Sources/App/Database/DatabaseMigrator.swift
+++ b/app/backend-swift/Sources/App/Database/DatabaseMigrator.swift
@@ -1,0 +1,138 @@
+import Fluent
+import SQLKit
+import Vapor
+
+struct EnsureSchemaMigration: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        createFolders(on: database)
+            .flatMap { self.createDecks(on: database) }
+            .flatMap { self.ensureDeckSourceText(on: database) }
+            .flatMap { self.ensureDeckFolderId(on: database) }
+            .flatMap { self.createQuestions(on: database) }
+            .flatMap { self.ensureQuestionLearningContent(on: database) }
+            .flatMap { self.createMastery(on: database) }
+            .flatMap { self.createAttempts(on: database) }
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.eventLoop.makeSucceededFuture(())
+    }
+
+    private func createFolders(on database: Database) -> EventLoopFuture<Void> {
+        database.sql().raw(
+            """
+            CREATE TABLE IF NOT EXISTS "Folders" (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                createdAt INTEGER DEFAULT (strftime('%s','now') * 1000)
+            );
+            """
+        ).run()
+    }
+
+    private func createDecks(on database: Database) -> EventLoopFuture<Void> {
+        database.sql().raw(
+            """
+            CREATE TABLE IF NOT EXISTS "Decks" (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                source_text TEXT DEFAULT '',
+                folderId TEXT,
+                createdAt INTEGER DEFAULT (strftime('%s','now') * 1000)
+            );
+            """
+        ).run()
+    }
+
+    private func ensureDeckSourceText(on database: Database) -> EventLoopFuture<Void> {
+        hasColumn("source_text", in: "Decks", on: database).flatMap { exists in
+            guard !exists else {
+                return database.eventLoop.makeSucceededFuture(())
+            }
+            return database.sql().raw(
+                """ALTER TABLE "Decks" ADD COLUMN "source_text" TEXT DEFAULT ''"""
+            ).run()
+        }
+    }
+
+    private func ensureDeckFolderId(on database: Database) -> EventLoopFuture<Void> {
+        hasColumn("folderId", in: "Decks", on: database).flatMap { exists in
+            guard !exists else {
+                return database.eventLoop.makeSucceededFuture(())
+            }
+            return database.sql().raw(
+                """ALTER TABLE "Decks" ADD COLUMN "folderId" TEXT"""
+            ).run()
+        }
+    }
+
+    private func createQuestions(on database: Database) -> EventLoopFuture<Void> {
+        database.sql().raw(
+            """
+            CREATE TABLE IF NOT EXISTS "Questions" (
+                id TEXT PRIMARY KEY,
+                deckId TEXT NOT NULL,
+                type TEXT NOT NULL,
+                prompt TEXT NOT NULL,
+                options TEXT,
+                correct_answer TEXT,
+                explanation TEXT,
+                learning_content TEXT,
+                tags TEXT,
+                difficulty INTEGER DEFAULT 3
+            );
+            """
+        ).run()
+    }
+
+    private func ensureQuestionLearningContent(on database: Database) -> EventLoopFuture<Void> {
+        hasColumn("learning_content", in: "Questions", on: database).flatMap { exists in
+            guard !exists else {
+                return database.eventLoop.makeSucceededFuture(())
+            }
+            return database.sql().raw(
+                """ALTER TABLE "Questions" ADD COLUMN "learning_content" TEXT"""
+            ).run()
+        }
+    }
+
+    private func createMastery(on database: Database) -> EventLoopFuture<Void> {
+        database.sql().raw(
+            """
+            CREATE TABLE IF NOT EXISTS "Mastery" (
+                questionId TEXT PRIMARY KEY,
+                correctCount INTEGER DEFAULT 0
+            );
+            """
+        ).run()
+    }
+
+    private func createAttempts(on database: Database) -> EventLoopFuture<Void> {
+        database.sql().raw(
+            """
+            CREATE TABLE IF NOT EXISTS "Attempts" (
+                id TEXT PRIMARY KEY,
+                questionId TEXT NOT NULL,
+                userAnswer TEXT,
+                correct INTEGER,
+                ts INTEGER
+            );
+            """
+        ).run()
+    }
+
+    private func hasColumn(_ column: String, in table: String, on database: Database) -> EventLoopFuture<Bool> {
+        let query: SQLQueryString = "PRAGMA table_info(\(identifier: table))"
+        return database.sql().raw(query).all().map { rows in
+            rows.contains { row in
+                row.column("name")?.string == column
+            }
+        }
+    }
+}
+
+enum DatabaseMigrator {
+    static func configure(_ app: Application) {
+        app.migrations.add(EnsureSchemaMigration())
+    }
+}

--- a/app/backend-swift/Sources/App/Database/DatabaseService.swift
+++ b/app/backend-swift/Sources/App/Database/DatabaseService.swift
@@ -48,7 +48,11 @@ enum DatabaseService {
 }
 
 extension Request {
-    func insertQuestion(_ question: InsertQuestion) -> EventLoopFuture<UUID> {
+    func insertQuestionFuture(_ question: InsertQuestion) -> EventLoopFuture<UUID> {
         DatabaseService.insertQuestion(question, on: db)
+    }
+
+    func insertQuestion(_ question: InsertQuestion) async throws -> UUID {
+        try await DatabaseService.insertQuestion(question, on: db).get()
     }
 }

--- a/app/backend-swift/Sources/App/Database/DatabaseService.swift
+++ b/app/backend-swift/Sources/App/Database/DatabaseService.swift
@@ -1,0 +1,54 @@
+import Fluent
+import Foundation
+import SQLKit
+import Vapor
+
+struct InsertQuestion {
+    var id: UUID?
+    var deckId: UUID
+    var type: String
+    var prompt: String
+    var options: [String: String]?
+    var correctAnswer: String?
+    var explanation: String?
+    var learningContent: String?
+    var tags: [String]?
+    var difficulty: Int?
+}
+
+enum DatabaseService {
+    static func insertQuestion(_ question: InsertQuestion, on database: Database) -> EventLoopFuture<UUID> {
+        let identifier = question.id ?? UUID()
+        let optionsJSON: String?
+        do {
+            optionsJSON = try question.options.map { options in
+                let data = try JSONEncoder().encode(options)
+                guard let json = String(data: data, encoding: .utf8) else {
+                    throw EncodingError.invalidValue(options, EncodingError.Context(
+                        codingPath: [],
+                        debugDescription: "Unable to encode options to UTF-8 string"
+                    ))
+                }
+                return json
+            }
+        } catch {
+            return database.eventLoop.makeFailedFuture(error)
+        }
+
+        let tags = question.tags?.joined(separator: ",")
+        let difficulty = question.difficulty ?? 3
+
+        let sql: SQLQueryString = """
+            INSERT INTO "Questions" (id, deckId, type, prompt, options, correct_answer, explanation, learning_content, tags, difficulty)
+            VALUES (\(bind: identifier.uuidString), \(bind: question.deckId.uuidString), \(bind: question.type), \(bind: question.prompt), \(bind: optionsJSON), \(bind: question.correctAnswer), \(bind: question.explanation), \(bind: question.learningContent), \(bind: tags), \(bind: difficulty))
+        """
+
+        return database.sql().raw(sql).run().transform(to: identifier)
+    }
+}
+
+extension Request {
+    func insertQuestion(_ question: InsertQuestion) -> EventLoopFuture<UUID> {
+        DatabaseService.insertQuestion(question, on: db)
+    }
+}

--- a/app/backend-swift/Sources/App/Services/AIQuestionGenerator.swift
+++ b/app/backend-swift/Sources/App/Services/AIQuestionGenerator.swift
@@ -1,0 +1,313 @@
+import Foundation
+import Vapor
+
+enum DeckQuestionType: String, Codable, CaseIterable {
+    case mcq = "MCQ"
+    case cloze = "CLOZE"
+    case short = "SHORT"
+}
+
+struct AIGeneratedQuestion: Codable {
+    enum CodingKeys: String, CodingKey {
+        case type
+        case prompt
+        case options
+        case correctAnswer = "correct_answer"
+        case explanation
+        case learningContent = "learning_content"
+        case tags
+        case difficulty
+    }
+
+    let type: DeckQuestionType
+    let prompt: String
+    let options: [String: String]?
+    let correctAnswer: String
+    let explanation: String
+    let learningContent: String
+    var tags: [String]
+    let difficulty: Int
+
+    init(type: DeckQuestionType,
+         prompt: String,
+         options: [String: String]?,
+         correctAnswer: String,
+         explanation: String,
+         learningContent: String,
+         tags: [String],
+         difficulty: Int) {
+        self.type = type
+        self.prompt = prompt
+        self.options = options
+        self.correctAnswer = correctAnswer
+        self.explanation = explanation
+        self.learningContent = learningContent
+        self.tags = tags
+        self.difficulty = difficulty
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        type = try container.decode(DeckQuestionType.self, forKey: .type)
+        prompt = try container.decode(String.self, forKey: .prompt)
+        options = try container.decodeIfPresent([String: String].self, forKey: .options)
+        correctAnswer = try container.decode(String.self, forKey: .correctAnswer)
+        explanation = try container.decode(String.self, forKey: .explanation)
+        learningContent = try container.decode(String.self, forKey: .learningContent)
+        let decodedTags = try container.decodeIfPresent([String].self, forKey: .tags) ?? []
+        tags = decodedTags
+        difficulty = try container.decode(Int.self, forKey: .difficulty)
+    }
+}
+
+private struct QuestionsEnvelope: Decodable {
+    let questions: [AIGeneratedQuestion]
+}
+
+enum AIQuestionGeneratorError: Error, LocalizedError {
+    case missingAPIKey
+    case invalidResponse(status: HTTPStatus, body: String)
+    case emptyContent
+    case decodingFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey:
+            return "OPENAI_API_KEY is not set"
+        case .invalidResponse(let status, let body):
+            return "OpenAI returned status \(status.code): \(body)"
+        case .emptyContent:
+            return "OpenAI response did not include content"
+        case .decodingFailed:
+            return "Failed to decode AI response"
+        }
+    }
+}
+
+enum AIQuestionGenerator {
+    static func generateBatch(text: String, batchSize: Int, on req: Request) async throws -> [AIGeneratedQuestion] {
+        let sections = splitIntoSections(text)
+        guard !sections.isEmpty else { return [] }
+
+        let perSection = max(1, Int(ceil(Double(batchSize) / Double(sections.count))))
+        var results: [AIGeneratedQuestion] = []
+        results.reserveCapacity(batchSize)
+
+        for (index, section) in sections.enumerated() {
+            do {
+                let prompt = buildPrompt(batchTarget: perSection, sourceText: section.content)
+                let content = try await callStructuredJSON(prompt: prompt, on: req)
+                let questions = try parseQuestions(content)
+                for var question in questions {
+                    var tags = question.tags
+                    tags.append("section:\(section.id)")
+                    var seen: Set<String> = []
+                    question.tags = tags.filter { tag in
+                        let (inserted, _) = seen.insert(tag)
+                        return inserted
+                    }
+                    results.append(question)
+                    if results.count >= batchSize { break }
+                }
+                if results.count >= batchSize { break }
+            } catch {
+                req.logger.error("AI generation failed for section \(index + 1): \(error.localizedDescription)")
+                throw error
+            }
+        }
+
+        return Array(results.prefix(batchSize))
+    }
+
+    private static func buildPrompt(batchTarget: Int, sourceText: String) -> String {
+        """
+        Generate high-quality study questions from the following text.
+
+        Distribution across the batch:
+        - 50% MCQ (4 options a/b/c/d; spread correct answers across different letters; avoid trivial answers; use realistic near-miss distractors that mirror common misconceptions; include a concise rationale for why each option is right or wrong)
+        - 25% Cloze (single blank '_____')
+        - 25% Short Answer
+
+        For EVERY question include these exact fields:
+        - type ("MCQ" | "CLOZE" | "SHORT")
+        - prompt (string)
+        - options (object with keys a,b,c,d). For CLOZE/SHORT still include options but set a,b,c,d to "".
+        - correct_answer (string)
+        - explanation (string; Explain why each option (a–d) is correct or incorrect.)
+        - learning_content (string; 2–4 sentence study note including concepts or facts needed to answer the question. State neutrally and avoid revealing the answer.)
+        - tags (array of topical strings)
+        - difficulty (integer 1–5)
+
+        Ground everything strictly in the source. Avoid duplicates; vary difficulty and tags.
+        - Use diverse question stems.
+        - Include scenario/application prompts.
+        - Mix straightforward recall with deeper analysis questions.
+        Write \(batchTarget) total.
+
+        SOURCE:
+        \(sourceText)
+        """
+    }
+
+    private static func splitIntoSections(_ text: String) -> [Section] {
+        let normalized = text.replacingOccurrences(of: "\r\n", with: "\n").replacingOccurrences(of: "\r", with: "\n")
+        let lines = normalized.split(omittingEmptySubsequences: false, whereSeparator: { $0 == "\n" })
+        var sections: [Section] = []
+        var current: Section?
+        var count = 0
+
+        for rawLine in lines {
+            let line = String(rawLine)
+            if line.range(of: "^#+\\s+", options: .regularExpression) != nil {
+                if let currentSection = current {
+                    sections.append(currentSection)
+                }
+                count += 1
+                current = Section(id: "\(count)", content: "")
+                continue
+            }
+
+            if current == nil {
+                current = Section(id: "1", content: "")
+                count = 1
+            }
+
+            current?.content.append(line)
+            current?.content.append("\n")
+        }
+
+        if let currentSection = current {
+            sections.append(currentSection)
+        }
+
+        if sections.isEmpty {
+            return [Section(id: "1", content: text)]
+        }
+
+        return sections
+    }
+
+    private static func parseQuestions(_ json: String) throws -> [AIGeneratedQuestion] {
+        let trimmed = json.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw AIQuestionGeneratorError.emptyContent }
+        guard let data = trimmed.data(using: .utf8) else { throw AIQuestionGeneratorError.decodingFailed }
+
+        do {
+            let decoder = JSONDecoder()
+            let envelope = try decoder.decode(QuestionsEnvelope.self, from: data)
+            return envelope.questions
+        } catch {
+            throw AIQuestionGeneratorError.decodingFailed
+        }
+    }
+
+    private static func callStructuredJSON(prompt: String, on req: Request) async throws -> String {
+        do {
+            return try await callChatCompletions(prompt: prompt, on: req)
+        } catch AIQuestionGeneratorError.decodingFailed {
+            throw error
+        } catch {
+            throw error
+        }
+    }
+
+    private static func callChatCompletions(prompt: String, on req: Request) async throws -> String {
+        guard let apiKey = Environment.get("OPENAI_API_KEY"), !apiKey.isEmpty else {
+            throw AIQuestionGeneratorError.missingAPIKey
+        }
+
+        let model = Environment.get("OPENAI_MODEL") ?? "gpt-4o-mini"
+        let maxRetries = Environment.get("OPENAI_MAX_RETRIES").flatMap(Int.init) ?? 2
+
+        let body = ChatCompletionsRequest(
+            model: model,
+            messages: [ChatCompletionsRequest.Message(role: "user", content: prompt)],
+            responseFormat: .init(type: "json_object"),
+            temperature: 0.7
+        )
+
+        var lastError: Error?
+        for attempt in 0...maxRetries {
+            do {
+                let response = try await req.client.post(URI(string: "https://api.openai.com/v1/chat/completions")) { request in
+                    request.headers.add(name: .authorization, value: "Bearer \(apiKey)")
+                    request.headers.add(name: .contentType, value: "application/json")
+                    try request.content.encode(body)
+                }
+
+                guard response.status == .ok else {
+                    let bodyString = response.body.flatMap { String(buffer: $0) } ?? ""
+                    throw AIQuestionGeneratorError.invalidResponse(status: response.status, body: bodyString)
+                }
+
+                guard let responseBody = response.body else {
+                    throw AIQuestionGeneratorError.emptyContent
+                }
+
+                let responseString = String(buffer: responseBody)
+                guard let data = responseString.data(using: .utf8) else {
+                    throw AIQuestionGeneratorError.emptyContent
+                }
+
+                let decoder = JSONDecoder()
+                let payload = try decoder.decode(ChatCompletionsResponse.self, from: data)
+                if let content = payload.choices.first?.message.content, !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    return content
+                }
+
+                throw AIQuestionGeneratorError.emptyContent
+            } catch {
+                lastError = error
+                if attempt < maxRetries {
+                    let delay = UInt64(500_000_000 * (attempt + 1))
+                    try await Task.sleep(nanoseconds: delay)
+                }
+            }
+        }
+
+        throw lastError ?? AIQuestionGeneratorError.emptyContent
+    }
+}
+
+private struct Section {
+    let id: String
+    var content: String
+}
+
+private struct ChatCompletionsRequest: Encodable {
+    struct Message: Encodable {
+        let role: String
+        let content: String
+    }
+
+    struct ResponseFormat: Encodable {
+        let type: String
+
+        enum CodingKeys: String, CodingKey {
+            case type
+        }
+    }
+
+    let model: String
+    let messages: [Message]
+    let responseFormat: ResponseFormat
+    let temperature: Double
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case messages
+        case responseFormat = "response_format"
+        case temperature
+    }
+}
+
+private struct ChatCompletionsResponse: Decodable {
+    struct Choice: Decodable {
+        struct Message: Decodable {
+            let content: String?
+        }
+        let message: Message
+    }
+
+    let choices: [Choice]
+}

--- a/app/backend-swift/Sources/App/Utilities/EventLoopFuture+Async.swift
+++ b/app/backend-swift/Sources/App/Utilities/EventLoopFuture+Async.swift
@@ -1,0 +1,17 @@
+import Foundation
+import NIOCore
+
+extension EventLoopFuture {
+    func get() async throws -> Value {
+        try await withCheckedThrowingContinuation { continuation in
+            whenComplete { result in
+                switch result {
+                case .success(let value):
+                    continuation.resume(returning: value)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/app/backend-swift/Sources/App/configure.swift
+++ b/app/backend-swift/Sources/App/configure.swift
@@ -23,5 +23,8 @@ public func configure(_ app: Application) throws {
     app.middleware.use(CORSMiddleware(configuration: corsConfiguration))
     app.middleware.use(ErrorMiddleware.default(environment: app.environment))
 
+    DatabaseMigrator.configure(app)
+    try app.autoMigrate().wait()
+
     try routes(app)
 }

--- a/app/backend-swift/Sources/App/configure.swift
+++ b/app/backend-swift/Sources/App/configure.swift
@@ -1,0 +1,27 @@
+import Vapor
+import Fluent
+import FluentSQLiteDriver
+
+public func configure(_ app: Application) throws {
+    if app.environment == .development {
+        app.logger.logLevel = .debug
+    }
+
+    // SQLite configuration mirrors the existing Node backend which uses data.sqlite in-place.
+    app.databases.use(.sqlite(.file("data.sqlite")), as: .sqlite)
+
+    // JSON payload size limit matches the Express configuration (default 10 MB).
+    let limitBytes = Environment.get("JSON_LIMIT").flatMap(Int.init) ?? 10 * 1024 * 1024
+    app.routes.defaultMaxBodySize = ByteCount(limitBytes)
+
+    // Align CORS behavior with Express' permissive configuration so the desktop shell can call it.
+    let corsConfiguration = CORSMiddleware.Configuration(
+        allowedOrigin: .any,
+        allowedMethods: [.GET, .POST, .PUT, .PATCH, .DELETE, .OPTIONS],
+        allowedHeaders: [.accept, .authorization, .contentType, .origin, .xRequestedWith]
+    )
+    app.middleware.use(CORSMiddleware(configuration: corsConfiguration))
+    app.middleware.use(ErrorMiddleware.default(environment: app.environment))
+
+    try routes(app)
+}

--- a/app/backend-swift/Sources/App/routes.swift
+++ b/app/backend-swift/Sources/App/routes.swift
@@ -1,0 +1,21 @@
+import Vapor
+
+public func routes(_ app: Application) throws {
+    app.get("health") { _ in
+        HealthResponse(ok: true)
+    }
+
+    let decks = app.grouped("decks")
+    let quiz = app.grouped("quiz")
+    let questions = app.grouped("questions")
+    let folders = app.grouped("folders")
+
+    try DecksController().boot(routes: decks)
+    try QuizController().boot(routes: quiz)
+    try QuestionsController().boot(routes: questions)
+    try FoldersController().boot(routes: folders)
+}
+
+struct HealthResponse: Content {
+    let ok: Bool
+}

--- a/app/backend-swift/Sources/Run/main.swift
+++ b/app/backend-swift/Sources/Run/main.swift
@@ -1,0 +1,34 @@
+import App
+import Vapor
+
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+var env = try Environment.detect()
+try LoggingSystem.bootstrap(from: &env)
+let app = Application(env)
+defer { app.shutdown() }
+
+try configure(app)
+
+taskNotifyReady()
+
+try app.run()
+
+private func taskNotifyReady() {
+    Task.detached {
+        guard let pipe = Environment.get("BACKEND_READY_PIPE") else { return }
+        pipe.withCString { cString in
+            let fd = open(cString, O_WRONLY | O_CLOEXEC)
+            guard fd >= 0 else { return }
+            defer { close(fd) }
+            let message = "ready\n"
+            message.withCString { ptr in
+                _ = write(fd, ptr, message.count)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new Vapor-based Swift package under `app/backend-swift` that mirrors the existing Express routing topology with placeholder controllers
- expose health, deck, quiz, question, and folder endpoints for the future Swift port and add process-ready notification
- document the Swift prototype build/run steps and ignore the Swift build artifacts

## Testing
- `swift build` *(fails: unable to fetch Vapor dependencies because outbound network access to GitHub is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc720e38883209b421aa6f371ea1e